### PR TITLE
feat: add docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,34 @@
-DATABASE_URL=postgresql://postgres@localhost:5432/workoutcool_local
+# Database Configuration
+# Format: postgresql://USER:PASSWORD@HOST:PORT/DATABASE
+DATABASE_URL="postgresql://username:password@localhost:5432/workout_cool"
 
-GOOGLE_CLIENT_ID=
-GOOGLE_CLIENT_SECRET=
+# Authentication
+# The URL where your application is running
+BETTER_AUTH_URL="http://localhost:3000"
+# Generate a secure random string using: openssl rand -base64 32
+BETTER_AUTH_SECRET="your-secret-key-here"
 
-RESEND_API_KEY=
+# Google OAuth
+# Get these from Google Cloud Console: https://console.cloud.google.com
+# Required scopes: email, profile
+GOOGLE_CLIENT_ID="your-google-client-id.apps.googleusercontent.com"
+GOOGLE_CLIENT_SECRET="your-google-client-secret"
 
-NODE_ENV=development
+# Email Service (Resend)
+# Get your API key from: https://resend.com
+RESEND_API_KEY="re_123456789"
+# Optional: Create an audience in Resend dashboard
+RESEND_AUDIENCE_ID="aud_123456789"
 
-BETTER_AUTH_SECRET=
-BETTER_AUTH_URL=http://localhost:3000
+# OpenPanel Integration
+# Get these from your OpenPanel dashboard
+OPENPANEL_SECRET_KEY="op_sk_123456789"
+NEXT_PUBLIC_OPENPANEL_CLIENT_ID="op_pk_123456789"
+
+# Facebook Pixel
+# Get this from Facebook Business Manager
+NEXT_PUBLIC_FACEBOOK_PIXEL_ID="123456789"
+
+# Environment
+# Options: development, production, test
+NODE_ENV="development"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+.PHONY: init dev up down db-reset db-migrate db-generate help
+
+help:
+	@echo "🚀 Workout Cool Development Commands"
+	@echo ""
+	@echo "📦 Database Management:"
+	@echo "  up          - Start PostgreSQL database using Docker Compose"
+	@echo "  down        - Stop all Docker Compose services"
+	@echo "  db-migrate  - Run Prisma migrations to update database schema"
+	@echo "  db-generate - Generate Prisma client for type-safe database access"
+	@echo "  db-reset    - Reset database (⚠️ Destructive! Drops all data)"
+	@echo ""
+	@echo "🛠️  Development:"
+	@echo "  dev         - Start Next.js development server"
+	@echo "  init        - Full setup: start DB, run migrations, and start dev server"
+	@echo ""
+	@echo "Usage: make <target>"
+	@echo "Example: make init"
+
+# Start Postgres with Docker Compose
+up:
+	docker compose up -d
+
+# Stop Docker Compose
+down:
+	docker compose down
+
+# Run Prisma migrations
+db-migrate:
+	npx prisma migrate deploy
+
+# Generate Prisma client
+db-generate:
+	npx prisma generate
+
+# Reset database (⚠️ destructive!)
+db-reset:
+	npx prisma migrate reset --force
+
+# Start the dev server
+dev:
+	pnpm dev
+
+# Initialize dev environment (start DB, run migration, start dev server)
+init: up db-migrate dev

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: init dev up down db-reset db-migrate db-generate help
+.PHONY: init dev up down db-reset db-migrate db-generate db-seed help
 
 help:
 	@echo "🚀 Workout Cool Development Commands"
@@ -9,10 +9,11 @@ help:
 	@echo "  db-migrate  - Run Prisma migrations to update database schema"
 	@echo "  db-generate - Generate Prisma client for type-safe database access"
 	@echo "  db-reset    - Reset database (⚠️ Destructive! Drops all data)"
+	@echo "  db-seed     - Seed database with sample data"
 	@echo ""
 	@echo "🛠️  Development:"
 	@echo "  dev         - Start Next.js development server"
-	@echo "  init        - Full setup: start DB, run migrations, and start dev server"
+	@echo "  init        - Full setup: start DB, run migrations, seed data, and start dev server"
 	@echo ""
 	@echo "Usage: make <target>"
 	@echo "Example: make init"
@@ -37,9 +38,13 @@ db-generate:
 db-reset:
 	npx prisma migrate reset --force
 
+# Seed database with sample data
+db-seed:
+	pnpm run import:exercises-full ./data/sample-exercises.csv
+
 # Start the dev server
 dev:
 	pnpm dev
 
-# Initialize dev environment (start DB, run migration, start dev server)
-init: up db-migrate dev
+# Initialize dev environment (start DB, run migration, seed data, start dev server)
+init: up db-migrate db-seed dev

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ management._
 ### Prerequisites
 
 - Node.js 18+
-- PostgreSQL database
+- Either:
+  - Docker
+  - OR PostgreSQL external database
 - pnpm (recommended) or npm
 
 ### Installation
@@ -103,18 +105,34 @@ management._
 
 4. **Set up the database**
 
+   #### Option 1: Using Docker
+
+   The project provides a convenient `make` command that handles everything:
+
    ```bash
-   npx prisma migrate deploy
-   npx prisma generate
+   make init
    ```
 
-5. **Start the development server**
+   This single command will:
+
+   - Start the PostgreSQL database using Docker
+   - Run database migrations
+   - Start the development server
+
+   #### Option 2: Manual PostgreSQL Setup
+
+   If you prefer to use your own PostgreSQL installation:
 
    ```bash
+   # Run migrations
+   npx prisma migrate deploy
+   npx prisma generate
+
+   # Start the development server
    pnpm dev
    ```
 
-6. **Open your browser** Navigate to [http://localhost:3000](http://localhost:3000)
+5. **Open your browser** Navigate to [http://localhost:3000](http://localhost:3000)
 
 ## Exercise Database Import
 

--- a/data/sample-exercises.csv
+++ b/data/sample-exercises.csv
@@ -1,0 +1,3 @@
+id,name,name_en,description,description_en,full_video_url,full_video_image_url,introduction,introduction_en,slug,slug_en,attribute_name,attribute_value
+157,"Fentes arrières à la barre","Barbell Reverse Lunges","<p>Stand upright...</p>","<p>Stand upright...</p>",https://youtube.com/...,https://img.youtube.com/...,slug-fr,slug-en,TYPE,STRENGTH
+157,"Fentes arrières à la barre","Barbell Reverse Lunges","<p>Stand upright...</p>","<p>Stand upright...</p>",https://youtube.com/...,https://img.youtube.com/...,slug-fr,slug-en,PRIMARY_MUSCLE,QUADRICEPS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  postgres:
+    image: postgres:15
+    restart: unless-stopped
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: username
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: workout_cool
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,11 @@ services:
       POSTGRES_DB: workout_cool
     volumes:
       - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U username -d workout_cool"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
 volumes:
   pgdata:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "old-vercel-build": "prisma generate && prisma migrate deploy && next build",
     "postinstall": "prisma generate",
     "lint": "next lint",
-    "import:exercises-full": "tsx scripts/import-exercises-with-attributes.ts"
+    "import:exercises-full": "tsx scripts/import-exercises-with-attributes.ts",
+    "db:seed": "pnpm run import:exercises-full ./data/sample-exercises.csv"
   },
   "resolutions": {
     "prettier": "^3.4.2"


### PR DESCRIPTION
## Description
Added Docker Compose configuration for PostgreSQL and Makefile commands to improve local development workflow.

## Changes
- Added `docker-compose.yml` with PostgreSQL service
- Created Makefile with development and database management commands
 - Updated `README.md`

## New Development Commands
- `make up` - Start PostgreSQL database
- `make down` - Stop database
- `make db-migrate` - Run Prisma migrations
- `make db-generate` - Generate Prisma client
- `make db-reset` - Reset database (⚠️ destructive)
-  `make db-seed`   - Seed database with sample data"
- `make dev` - Start Next.js development server
- `make init` - Full setup (DB + migrations + dev server)

## Why
- Simplifies local development setup
- Makes it easier for contributors to get started

## Testing
- [X] Verify `make init` completes full setup process


## Additional Notes
- Database credentials are set to default values for local development
- Volume `pgdata` ensures data persistence between container restarts
- Container is configured to restart automatically unless stopped manually