### PR TITLE
fix: remove duplicate BETTER_AUTH_* default env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,9 +20,6 @@ RESEND_API_KEY="re_123456789"
 # Optional: Create an audience in Resend dashboard
 RESEND_AUDIENCE_ID="aud_123456789"
 
-BETTER_AUTH_SECRET=
-BETTER_AUTH_URL=http://localhost:3000
-
 # OpenPanel Integration
 # Get these from your OpenPanel dashboard
 OPENPANEL_SECRET_KEY="op_sk_123456789"


### PR DESCRIPTION
This PR removes the duplicated `BETTER_AUTH_URL` & `BETTER_AUTH_SECRET` variables. Copying the default `.env.example` to build a docker image using the PR https://github.com/Snouzy/workout-cool/pull/34 causes an error:

```
57.85 ❌ Invalid environment variables: [
57.85   {
57.85     code: 'too_small',
57.85     minimum: 1,
57.85     type: 'string',
57.85     inclusive: true,
57.85     exact: false,
57.85     message: 'String must contain at least 1 character(s)',
57.85     path: [ 'BETTER_AUTH_SECRET' ]
57.85   }
```

which is due to the second (duplicated) `BETTER_AUTH_SECRET` being empty.