### PR TITLE
fix: remove the leading / to prevent callback url from being //?signin=true

### DIFF
--- a/src/features/auth/signin/model/useSignIn.ts
+++ b/src/features/auth/signin/model/useSignIn.ts
@@ -11,7 +11,7 @@ export const useSignIn = () => {
     const response = await authClient.signIn.email({
       email: values.email,
       password: values.password,
-      callbackURL: `/${paths.root}?signin=true`,
+      callbackURL: `${paths.root}?signin=true`,
     });
 
     if (response?.error) {


### PR DESCRIPTION
## 📝 Description

The `callbackURL` for `better-auth` tells it where to redirect after the user logs in. Given the `paths.root` as `/` prefixing with a `/${paths.root}?signin=true` causes an error, preventing users from logging in. 

<img width="1186" alt="image" src="https://github.com/user-attachments/assets/b32c3701-6c24-44dd-9f12-5833f3a51452" />


## 📋 Checklist

- [x] My code follows the project conventions
- [ ] This PR includes breaking changes
- [ ] I have updated the documentation if necessary

## 🗃️ Prisma Migrations (if applicable)

- [ ] I have created a migration
- [ ] I have tested the migration locally

## 🔗 Related Issues

After this commit, https://github.com/Snouzy/workout-cool/commit/b67986f29879f0adbef3f2be8882b2dced4b6fc7 I think we need to discuss if we need the email verification and how to handle it.

I looked into using the middleware to enforce the concept of protected routes so we can check if the authenticated user's email is verified else we always redirect them to the `email-verification` page, but it seems there's no "clean" way of getting the current user (only the session cookie is possible). 

Hence, for now, I'll say this PR closes https://github.com/Snouzy/workout-cool/issues/62
