### PR TITLE
fix: leading zeros in the inputs

### DIFF
--- a/src/features/workout-session/ui/workout-session-set.tsx
+++ b/src/features/workout-session/ui/workout-session-set.tsx
@@ -26,12 +26,14 @@ export function WorkoutSessionSet({ set, setIndex, onChange, onFinish, onRemove 
   };
 
   const handleValueIntChange = (columnIndex: number) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.target.value = e.target.value === "" ? "" : e.target.value.replace(/^0+(?=\d)/, "") || "0";
     const newValuesInt = Array.isArray(set.valuesInt) ? [...set.valuesInt] : [];
     newValuesInt[columnIndex] = e.target.value ? parseInt(e.target.value, 10) : 0;
     onChange(setIndex, { valuesInt: newValuesInt });
   };
 
   const handleValueSecChange = (columnIndex: number) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.target.value = e.target.value === "" ? "" : e.target.value.replace(/^0+(?=\d)/, "") || "0";
     const newValuesSec = Array.isArray(set.valuesSec) ? [...set.valuesSec] : [];
     newValuesSec[columnIndex] = e.target.value ? parseInt(e.target.value, 10) : 0;
     onChange(setIndex, { valuesSec: newValuesSec });


### PR DESCRIPTION
## 📝 Description

Fixed input behavior in workout set forms to automatically remove leading zeros when users type values. Previously, users could enter values like "002" which would remain displayed as such, causing potential confusion. Now, leading zeros are immediately stripped from numeric inputs via regex while maintaining proper functionality for empty values and single zeros.

## 📋 Checklist

- [x] My code follows the project conventions
- [ ] This PR includes breaking changes
- [ ] I have updated documentation if necessary

## 🗃️ Prisma Migrations (if applicable)

- [ ] I have created a migration
- [ ] I have tested the migration locally

## 🔗 Related Issues

Fixes #97 
