### PR TITLE
fix: add missing trad in commons

### DIFF
--- a/locales/es.ts
+++ b/locales/es.ts
@@ -591,6 +591,7 @@ export default {
     change_language: "Cambiar idioma",
     subscription: "Suscripción",
     manage_subscription: "Gestionar suscripción",
+    become_premium: "Torne-se Premium",
     in_progress: "En progreso",
     premium: "Premium",
     free: "Gratis",

--- a/locales/pt.ts
+++ b/locales/pt.ts
@@ -593,6 +593,7 @@ export default {
     premium: "Premium",
     subscription: "Abonamento",
     manage_subscription: "Gerir abonamento",
+    become_premium: "Torne-se Premium",
     free: "Gratuito",
     new: "Novo",
   },

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -592,6 +592,7 @@ export default {
     in_progress: "В процессе",
     subscription: "Подписка",
     manage_subscription: "Управление подпиской",
+    become_premium: "Стань Премиум",
     premium: "Премиум",
     free: "Бесплатно",
     new: "Новый",

--- a/locales/zh-CN.ts
+++ b/locales/zh-CN.ts
@@ -584,6 +584,7 @@ export default {
     change_language: "更改语言",
     subscription: "订阅",
     manage_subscription: "管理订阅",
+    become_premium: "成为高级",
     in_progress: "进行中",
     premium: "高级",
     free: "免费",


### PR DESCRIPTION
## 📝 Description

This PR adds traduction for missing `commons.become_premium`

