### PR TITLE
Fix: Removes animate-pulse from calorie calculators

### DIFF
--- a/app/[locale]/(app)/tools/calorie-calculator/CalorieCalculatorClient.tsx
+++ b/app/[locale]/(app)/tools/calorie-calculator/CalorieCalculatorClient.tsx
@@ -74,9 +74,7 @@ export function CalorieCalculatorClient() {
           {/* Calculate Button */}
           <button
             aria-label={t("tools.calorie-calculator.calculate")}
-            className={`w-full py-4 px-6 rounded-xl bg-gradient-to-r from-[#4F8EF7] to-[#238BE6] text-white font-bold text-lg transition-all duration-300 hover:scale-[1.02] hover:shadow-lg hover:shadow-primary/25 active:scale-[0.98] touch-manipulation ${
-              isCalculating ? "animate-pulse" : ""
-            }`}
+            className={`w-full py-4 px-6 rounded-xl bg-gradient-to-r from-[#4F8EF7] to-[#238BE6] text-white font-bold text-lg transition-all duration-300 hover:scale-[1.02] hover:shadow-lg hover:shadow-primary/25 active:scale-[0.98] touch-manipulation`}
             disabled={isCalculating}
             onClick={handleCalculate}
           >

--- a/app/[locale]/(app)/tools/calorie-calculator/calorie-calculator-comparison/CalorieCalculatorComparison.tsx
+++ b/app/[locale]/(app)/tools/calorie-calculator/calorie-calculator-comparison/CalorieCalculatorComparison.tsx
@@ -143,9 +143,7 @@ export function CalorieCalculatorComparison() {
           {/* Calculate Button */}
           <button
             aria-label={t("tools.calorie-calculator.calculate")}
-            className={`w-full py-4 px-6 rounded-xl bg-gradient-to-r from-[#06B6D4] to-[#3B82F6] text-white font-bold text-lg transition-all duration-300 hover:scale-[1.02] hover:shadow-lg hover:shadow-primary/25 active:scale-[0.98] touch-manipulation ${
-              isCalculating ? "animate-pulse" : ""
-            }`}
+            className={`w-full py-4 px-6 rounded-xl bg-gradient-to-r from-[#06B6D4] to-[#3B82F6] text-white font-bold text-lg transition-all duration-300 hover:scale-[1.02] hover:shadow-lg hover:shadow-primary/25 active:scale-[0.98] touch-manipulation`}
             disabled={isCalculating}
             onClick={handleCalculate}
           >

--- a/app/[locale]/(app)/tools/calorie-calculator/components/ResultsDisplay.tsx
+++ b/app/[locale]/(app)/tools/calorie-calculator/components/ResultsDisplay.tsx
@@ -68,7 +68,7 @@ export function ResultsDisplay({ results }: ResultsDisplayProps) {
           <div className="text-sm text-base-content/60 dark:text-base-content/50 font-medium">kcal</div>
         </div>
 
-        <div className="bg-gradient-to-br from-[#4F8EF7]/30 to-[#238BE6]/20 dark:from-[#4F8EF7]/20 dark:to-[#238BE6]/10 rounded-xl p-4 text-center border-2 border-[#4F8EF7]/40 dark:border-[#4F8EF7]/30 transition-all duration-300 hover:scale-105 animate-pulse">
+        <div className="bg-gradient-to-br from-[#4F8EF7]/30 to-[#238BE6]/20 dark:from-[#4F8EF7]/20 dark:to-[#238BE6]/10 rounded-xl p-4 text-center border-2 border-[#4F8EF7]/40 dark:border-[#4F8EF7]/30 transition-all duration-300 hover:scale-105">
           <div className="text-sm text-[#4F8EF7] dark:text-[#4F8EF7]/90 mb-1 font-bold uppercase tracking-wider">
             {t("tools.calorie-calculator.results.target")}
           </div>

--- a/app/[locale]/(app)/tools/calorie-calculator/cunningham-calculator/CalorieCalculatorClient.tsx
+++ b/app/[locale]/(app)/tools/calorie-calculator/cunningham-calculator/CalorieCalculatorClient.tsx
@@ -79,9 +79,7 @@ export function CalorieCalculatorClient() {
           {/* Calculate Button */}
           <button
             aria-label={t("tools.calorie-calculator.calculate")}
-            className={`w-full py-4 px-6 rounded-xl bg-gradient-to-r from-[#8B5CF6] to-[#7C3AED] text-white font-bold text-lg transition-all duration-300 hover:scale-[1.02] hover:shadow-lg hover:shadow-primary/25 active:scale-[0.98] touch-manipulation ${
-              isCalculating ? "animate-pulse" : ""
-            }`}
+            className={`w-full py-4 px-6 rounded-xl bg-gradient-to-r from-[#8B5CF6] to-[#7C3AED] text-white font-bold text-lg transition-all duration-300 hover:scale-[1.02] hover:shadow-lg hover:shadow-primary/25 active:scale-[0.98] touch-manipulation`}
             disabled={isCalculating}
             onClick={handleCalculate}
           >

--- a/app/[locale]/(app)/tools/calorie-calculator/cunningham-calculator/components/ResultsDisplay.tsx
+++ b/app/[locale]/(app)/tools/calorie-calculator/cunningham-calculator/components/ResultsDisplay.tsx
@@ -68,7 +68,7 @@ export function ResultsDisplay({ results }: ResultsDisplayProps) {
           <div className="text-sm text-base-content/60 dark:text-base-content/50 font-medium">kcal</div>
         </div>
 
-        <div className="bg-gradient-to-br from-[#4F8EF7]/30 to-[#238BE6]/20 dark:from-[#4F8EF7]/20 dark:to-[#238BE6]/10 rounded-xl p-4 text-center border-2 border-[#4F8EF7]/40 dark:border-[#4F8EF7]/30 transition-all duration-300 hover:scale-105 animate-pulse">
+        <div className="bg-gradient-to-br from-[#4F8EF7]/30 to-[#238BE6]/20 dark:from-[#4F8EF7]/20 dark:to-[#238BE6]/10 rounded-xl p-4 text-center border-2 border-[#4F8EF7]/40 dark:border-[#4F8EF7]/30 transition-all duration-300 hover:scale-105">
           <div className="text-sm text-[#4F8EF7] dark:text-[#4F8EF7]/90 mb-1 font-bold uppercase tracking-wider">
             {t("tools.calorie-calculator.results.target")}
           </div>

--- a/app/[locale]/(app)/tools/calorie-calculator/harris-benedict-calculator/CalorieCalculatorClient.tsx
+++ b/app/[locale]/(app)/tools/calorie-calculator/harris-benedict-calculator/CalorieCalculatorClient.tsx
@@ -74,9 +74,7 @@ export function CalorieCalculatorClient() {
           {/* Calculate Button */}
           <button
             aria-label={t("tools.calorie-calculator.calculate")}
-            className={`w-full py-4 px-6 rounded-xl bg-gradient-to-r from-[#25CB78] to-[#22C55E] text-white font-bold text-lg transition-all duration-300 hover:scale-[1.02] hover:shadow-lg hover:shadow-primary/25 active:scale-[0.98] touch-manipulation ${
-              isCalculating ? "animate-pulse" : ""
-            }`}
+            className={`w-full py-4 px-6 rounded-xl bg-gradient-to-r from-[#25CB78] to-[#22C55E] text-white font-bold text-lg transition-all duration-300 hover:scale-[1.02] hover:shadow-lg hover:shadow-primary/25 active:scale-[0.98] touch-manipulation`}
             disabled={isCalculating}
             onClick={handleCalculate}
           >

--- a/app/[locale]/(app)/tools/calorie-calculator/harris-benedict-calculator/components/ResultsDisplay.tsx
+++ b/app/[locale]/(app)/tools/calorie-calculator/harris-benedict-calculator/components/ResultsDisplay.tsx
@@ -68,7 +68,7 @@ export function ResultsDisplay({ results }: ResultsDisplayProps) {
           <div className="text-sm text-base-content/60 dark:text-base-content/50 font-medium">kcal</div>
         </div>
 
-        <div className="bg-gradient-to-br from-[#4F8EF7]/30 to-[#238BE6]/20 dark:from-[#4F8EF7]/20 dark:to-[#238BE6]/10 rounded-xl p-4 text-center border-2 border-[#4F8EF7]/40 dark:border-[#4F8EF7]/30 transition-all duration-300 hover:scale-105 animate-pulse">
+        <div className="bg-gradient-to-br from-[#4F8EF7]/30 to-[#238BE6]/20 dark:from-[#4F8EF7]/20 dark:to-[#238BE6]/10 rounded-xl p-4 text-center border-2 border-[#4F8EF7]/40 dark:border-[#4F8EF7]/30 transition-all duration-300 hover:scale-105">
           <div className="text-sm text-[#4F8EF7] dark:text-[#4F8EF7]/90 mb-1 font-bold uppercase tracking-wider">
             {t("tools.calorie-calculator.results.target")}
           </div>

--- a/app/[locale]/(app)/tools/calorie-calculator/katch-mcardle-calculator/CalorieCalculatorClient.tsx
+++ b/app/[locale]/(app)/tools/calorie-calculator/katch-mcardle-calculator/CalorieCalculatorClient.tsx
@@ -79,9 +79,7 @@ export function CalorieCalculatorClient() {
           {/* Calculate Button */}
           <button
             aria-label={t("tools.calorie-calculator.calculate")}
-            className={`w-full py-4 px-6 rounded-xl bg-gradient-to-r from-[#FF5722] to-[#EF4444] text-white font-bold text-lg transition-all duration-300 hover:scale-[1.02] hover:shadow-lg hover:shadow-primary/25 active:scale-[0.98] touch-manipulation ${
-              isCalculating ? "animate-pulse" : ""
-            }`}
+            className={`w-full py-4 px-6 rounded-xl bg-gradient-to-r from-[#FF5722] to-[#EF4444] text-white font-bold text-lg transition-all duration-300 hover:scale-[1.02] hover:shadow-lg hover:shadow-primary/25 active:scale-[0.98] touch-manipulation`}
             disabled={isCalculating}
             onClick={handleCalculate}
           >

--- a/app/[locale]/(app)/tools/calorie-calculator/katch-mcardle-calculator/components/ResultsDisplay.tsx
+++ b/app/[locale]/(app)/tools/calorie-calculator/katch-mcardle-calculator/components/ResultsDisplay.tsx
@@ -68,7 +68,7 @@ export function ResultsDisplay({ results }: ResultsDisplayProps) {
           <div className="text-sm text-base-content/60 dark:text-base-content/50 font-medium">kcal</div>
         </div>
 
-        <div className="bg-gradient-to-br from-[#4F8EF7]/30 to-[#238BE6]/20 dark:from-[#4F8EF7]/20 dark:to-[#238BE6]/10 rounded-xl p-4 text-center border-2 border-[#4F8EF7]/40 dark:border-[#4F8EF7]/30 transition-all duration-300 hover:scale-105 animate-pulse">
+        <div className="bg-gradient-to-br from-[#4F8EF7]/30 to-[#238BE6]/20 dark:from-[#4F8EF7]/20 dark:to-[#238BE6]/10 rounded-xl p-4 text-center border-2 border-[#4F8EF7]/40 dark:border-[#4F8EF7]/30 transition-all duration-300 hover:scale-105">
           <div className="text-sm text-[#4F8EF7] dark:text-[#4F8EF7]/90 mb-1 font-bold uppercase tracking-wider">
             {t("tools.calorie-calculator.results.target")}
           </div>

--- a/app/[locale]/(app)/tools/calorie-calculator/mifflin-st-jeor-calculator/CalorieCalculatorClient.tsx
+++ b/app/[locale]/(app)/tools/calorie-calculator/mifflin-st-jeor-calculator/CalorieCalculatorClient.tsx
@@ -74,9 +74,7 @@ export function CalorieCalculatorClient() {
           {/* Calculate Button */}
           <button
             aria-label={t("tools.calorie-calculator.calculate")}
-            className={`w-full py-4 px-6 rounded-xl bg-gradient-to-r from-[#4F8EF7] to-[#238BE6] text-white font-bold text-lg transition-all duration-300 hover:scale-[1.02] hover:shadow-lg hover:shadow-primary/25 active:scale-[0.98] touch-manipulation ${
-              isCalculating ? "animate-pulse" : ""
-            }`}
+            className={`w-full py-4 px-6 rounded-xl bg-gradient-to-r from-[#4F8EF7] to-[#238BE6] text-white font-bold text-lg transition-all duration-300 hover:scale-[1.02] hover:shadow-lg hover:shadow-primary/25 active:scale-[0.98] touch-manipulation`}
             disabled={isCalculating}
             onClick={handleCalculate}
           >

--- a/app/[locale]/(app)/tools/calorie-calculator/mifflin-st-jeor-calculator/components/ResultsDisplay.tsx
+++ b/app/[locale]/(app)/tools/calorie-calculator/mifflin-st-jeor-calculator/components/ResultsDisplay.tsx
@@ -68,7 +68,7 @@ export function ResultsDisplay({ results }: ResultsDisplayProps) {
           <div className="text-sm text-base-content/60 dark:text-base-content/50 font-medium">kcal</div>
         </div>
 
-        <div className="bg-gradient-to-br from-[#4F8EF7]/30 to-[#238BE6]/20 dark:from-[#4F8EF7]/20 dark:to-[#238BE6]/10 rounded-xl p-4 text-center border-2 border-[#4F8EF7]/40 dark:border-[#4F8EF7]/30 transition-all duration-300 hover:scale-105 animate-pulse">
+        <div className="bg-gradient-to-br from-[#4F8EF7]/30 to-[#238BE6]/20 dark:from-[#4F8EF7]/20 dark:to-[#238BE6]/10 rounded-xl p-4 text-center border-2 border-[#4F8EF7]/40 dark:border-[#4F8EF7]/30 transition-all duration-300 hover:scale-105">
           <div className="text-sm text-[#4F8EF7] dark:text-[#4F8EF7]/90 mb-1 font-bold uppercase tracking-wider">
             {t("tools.calorie-calculator.results.target")}
           </div>

--- a/app/[locale]/(app)/tools/calorie-calculator/oxford-calculator/CalorieCalculatorClient.tsx
+++ b/app/[locale]/(app)/tools/calorie-calculator/oxford-calculator/CalorieCalculatorClient.tsx
@@ -74,9 +74,7 @@ export function CalorieCalculatorClient() {
           {/* Calculate Button */}
           <button
             aria-label={t("tools.calorie-calculator.calculate")}
-            className={`w-full py-4 px-6 rounded-xl bg-gradient-to-r from-[#25CB78] to-[#22C55E] text-white font-bold text-lg transition-all duration-300 hover:scale-[1.02] hover:shadow-lg hover:shadow-primary/25 active:scale-[0.98] touch-manipulation ${
-              isCalculating ? "animate-pulse" : ""
-            }`}
+            className={`w-full py-4 px-6 rounded-xl bg-gradient-to-r from-[#25CB78] to-[#22C55E] text-white font-bold text-lg transition-all duration-300 hover:scale-[1.02] hover:shadow-lg hover:shadow-primary/25 active:scale-[0.98] touch-manipulation`}
             disabled={isCalculating}
             onClick={handleCalculate}
           >

--- a/app/[locale]/(app)/tools/calorie-calculator/oxford-calculator/components/ResultsDisplay.tsx
+++ b/app/[locale]/(app)/tools/calorie-calculator/oxford-calculator/components/ResultsDisplay.tsx
@@ -68,7 +68,7 @@ export function ResultsDisplay({ results }: ResultsDisplayProps) {
           <div className="text-sm text-base-content/60 dark:text-base-content/50 font-medium">kcal</div>
         </div>
 
-        <div className="bg-gradient-to-br from-[#4F8EF7]/30 to-[#238BE6]/20 dark:from-[#4F8EF7]/20 dark:to-[#238BE6]/10 rounded-xl p-4 text-center border-2 border-[#4F8EF7]/40 dark:border-[#4F8EF7]/30 transition-all duration-300 hover:scale-105 animate-pulse">
+        <div className="bg-gradient-to-br from-[#4F8EF7]/30 to-[#238BE6]/20 dark:from-[#4F8EF7]/20 dark:to-[#238BE6]/10 rounded-xl p-4 text-center border-2 border-[#4F8EF7]/40 dark:border-[#4F8EF7]/30 transition-all duration-300 hover:scale-105">
           <div className="text-sm text-[#4F8EF7] dark:text-[#4F8EF7]/90 mb-1 font-bold uppercase tracking-wider">
             {t("tools.calorie-calculator.results.target")}
           </div>


### PR DESCRIPTION
## 📝 Description

This removes the `animate-pulse` class from calculator button and calorie results components to improve animations.

## 📋 Checklist

- [x] My code follows the project conventions
- [ ] This PR includes breaking changes
- [ ] I have updated documentation if necessary

## 🗃️ Prisma Migrations (if applicable)

- [ ] I have created a migration
- [ ] I have tested the migration locally

## 📸 Screenshots (if applicable)

https://github.com/user-attachments/assets/b222f40c-e998-4458-aa44-3af322fd2a85

## 🔗 Related Issues

Fixes #121
