### PR TITLE
ci(ghcr-images): manual dispatch and no cache build

### DIFF
--- a/.github/workflows/publish-ghcr-image.yml
+++ b/.github/workflows/publish-ghcr-image.yml
@@ -3,10 +3,13 @@ name: Publish Docker GHCR Image
 on:
   release:
     types: [published]
-  push:
-    branches:
-      - ci/fix-ghcr-publish
-
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag for the Docker image"
+        required: true
+        default: "latest"
+        type: string
 permissions:
   contents: read
   packages: write
@@ -26,7 +29,7 @@ jobs:
 
       - name: Set image tag
         id: vars
-        run: echo "tag=v1.2.4" >> $GITHUB_OUTPUT
+        run: echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
 
       - name: Build Docker image
         run: |

--- a/.github/workflows/publish-ghcr-image.yml
+++ b/.github/workflows/publish-ghcr-image.yml
@@ -30,12 +30,12 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker build . \
-                    --tag ghcr.io/lucasnevespereira/workout-cool:${{ steps.vars.outputs.tag }} \
-                    --tag ghcr.io/lucasnevespereira/workout-cool:latest
+          docker build --no-cache . \
+                    --tag ghcr.io/snouzy/workout-cool:${{ steps.vars.outputs.tag }} \
+                    --tag ghcr.io/snouzy/workout-cool:latest
 
       - name: Push Docker image (release tag)
-        run: docker push ghcr.io/lucasnevespereira/workout-cool:${{ steps.vars.outputs.tag }}
+        run: docker push ghcr.io/snouzy/workout-cool:${{ steps.vars.outputs.tag }}
 
       - name: Push Docker image (latest tag)
-        run: docker push ghcr.io/lucasnevespereira/workout-cool:latest
+        run: docker push ghcr.io/snouzy/workout-cool:latest

--- a/.github/workflows/publish-ghcr-image.yml
+++ b/.github/workflows/publish-ghcr-image.yml
@@ -3,6 +3,9 @@ name: Publish Docker GHCR Image
 on:
   release:
     types: [published]
+  push:
+    branches:
+      - ci/fix-ghcr-publish
 
 permissions:
   contents: read
@@ -23,16 +26,16 @@ jobs:
 
       - name: Set image tag
         id: vars
-        run: echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+        run: echo "tag=v1.2.4" >> $GITHUB_OUTPUT
 
       - name: Build Docker image
         run: |
           docker build . \
-                    --tag ghcr.io/snouzy/workout-cool:${{ steps.vars.outputs.tag }} \
-                    --tag ghcr.io/snouzy/workout-cool:latest
+                    --tag ghcr.io/lucasnevespereira/workout-cool:${{ steps.vars.outputs.tag }} \
+                    --tag ghcr.io/lucasnevespereira/workout-cool:latest
 
       - name: Push Docker image (release tag)
-        run: docker push ghcr.io/snouzy/workout-cool:${{ steps.vars.outputs.tag }}
+        run: docker push ghcr.io/lucasnevespereira/workout-cool:${{ steps.vars.outputs.tag }}
 
       - name: Push Docker image (latest tag)
-        run: docker push ghcr.io/snouzy/workout-cool:latest
+        run: docker push ghcr.io/lucasnevespereira/workout-cool:latest


### PR DESCRIPTION
## 📝 Description

Improve publish images to github container registry (ghcr) by:
- adding a manual dispatch
- adding a build with no cache


