### PR TITLE
doc: Add links to translated README versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@
   </p>
   <!-- Keep these links. Translations will automatically update with the README. -->
   <a href="https://readme-i18n.com/Snouzy/workout-cool?lang=de">Deutsch</a> | 
-  <a href="https://readme-i18n.com/Snouzy/workout-cool?lang=en">English</a> | 
   <a href="https://readme-i18n.com/Snouzy/workout-cool?lang=es">Español</a> | 
   <a href="https://readme-i18n.com/Snouzy/workout-cool?lang=fr">français</a> | 
   <a href="https://readme-i18n.com/Snouzy/workout-cool?lang=ja">日本語</a> | 


### PR DESCRIPTION
Added language selection links to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese.

The updated links can be previewed in my forked repository: https://github.com/dowithless/workout-cool/tree/patch-1

## 📝 Description

<!-- Briefly describe the changes made -->

## 📋 Checklist

- [ ] My code follows the project conventions
- [ ] This PR includes breaking changes
- [ ] I have updated documentation if necessary

## 🗃️ Prisma Migrations (if applicable)

- [ ] I have created a migration
- [ ] I have tested the migration locally

## 📸 Screenshots (if applicable)

<!-- Add screenshots for visual changes -->

## 🔗 Related Issues

<!-- Reference issues: Closes #123, Fixes #456 -->
