### PR TITLE
fix(ci): corrected tag parsing

### DIFF
--- a/.github/workflows/publish-ghcr-image.yml
+++ b/.github/workflows/publish-ghcr-image.yml
@@ -31,8 +31,10 @@ jobs:
         id: vars
         run: |
           if [ "${{ github.event_name }}" = "release" ]; then
+            # Get the release tag name
+            RELEASE_TAG="${{ github.event.release.tag_name }}"
             # Remove 'v' prefix if present for Docker tag
-            tag="${github.event.release.tag_name#v}"
+            tag="${RELEASE_TAG#v}"
             echo "tag=$tag" >> $GITHUB_OUTPUT
           else
             echo "tag=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## 📝 Description

This PR resolves the `bad substitution` error when parsing release tags. Apparently [GitHub Actions context variables](https://docs.github.com/en/actions/learn-github-actions/contexts) (like `github.event.release.tag_name`) cannot directly use shell parameters expansions (`#v`)

To fix this, we now first assign the `github.event.release.tag_name` to a shell variable in order to apply the parameter expansion (`#v`)
