### PR TITLE
chore: add deps target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,11 @@ help:
 	@echo "  db-seed     - Seed database"
 	@echo ""
 
+
+# Install Dependencies
+deps:
+	pnpm install --frozen-lockfile
+
 # Start Postgres with Docker Compose
 up:
 	docker compose up -d postgres
@@ -32,5 +37,5 @@ db-seed:
 	pnpm run import:exercises-full ./data/sample-exercises.csv
 
 # Start the dev server (with DB, migrate, seed)
-dev: up db-migrate db-generate db-seed
+dev: up deps db-migrate db-generate db-seed
 	pnpm dev


### PR DESCRIPTION
## 📝 Description

Added a new `deps` Makefile target to install project dependencies like `pnpm`, and made it part of the dev workflow. 
This change ensures developers won’t forget to install dependencies when running `make dev`.

## 📋 Checklist

- [x] My code follows the project conventions
- [ ] This PR includes breaking changes
- [ ] I have updated documentation if necessary

## 🔗 Related Issues

User feedback from Discord:
> Just wanted to ask if as part of pre-process running of the docker container you can add in a line to install npm and pnpm packages as part of the make file or something.
