### PR TITLE
fix(env): updated db configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
 # Database Configuration
-POSTGRES_USER=my-user
-POSTGRES_PASSWORD=my-password
+POSTGRES_USER=username
+POSTGRES_PASSWORD=password
 POSTGRES_DB=workout-cool
 DB_HOST=localhost
 DB_PORT=5432
 # Format: postgresql://USER:PASSWORD@HOST:PORT/DATABASE
-DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DB_HOST}:${DB_PORT}/${POSTGRES_DB}
+DATABASE_URL=postgresql://username:password@localhost:5432/workout_cool
 
 # Authentication
 # The URL where your application is running


### PR DESCRIPTION
## 📝 Description

This PR updates the `.env.example` file to use a hardcoded `DATABASE_URL` instead of composing it from multiple variables (e.g., `${POSTGRES_USER}`, `${DB_HOST}`, etc.).

While this approach might appear cleaner, `.env` files **do not support variable interpolation or expansion by default** — meaning that `${VAR}` placeholders are not automatically replaced by their defined values.

### 📚 Reference

According to the `dotenv-expand` documentation (an official extension of `dotenv`):

> “dotenv does not support variable expansion. If you want to expand environment variables inside your `.env` files, you must use dotenv-expand.”
>
> 🔗 https://github.com/motdotla/dotenv-expand

By hardcoding the `DATABASE_URL`, we ensure predictable behavior across all environments and reduce setup errors for new developers.

## 📋 Checklist

- [x] My code follows the project conventions  
- [ ] This PR includes breaking changes  
- [ ] I have updated documentation if necessary  

## 🔗 Related Issues

User feedback from Discord
> I followed the docker instructions but I think there's an issue with my .env, I copied the .env.example and ran the makefile with the example env but it keeps returning similar to this other user Authentication failed against database server, the provided database credentials for my-user are not valid