### PR TITLE
doc: remove unlinked roadmap from table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@
     </a>
   </p>
   <!-- Keep these links. Translations will automatically update with the README. -->
-  <a href="https://readme-i18n.com/Snouzy/workout-cool?lang=de">Deutsch</a> | 
-  <a href="https://readme-i18n.com/Snouzy/workout-cool?lang=es">Español</a> | 
-  <a href="https://readme-i18n.com/Snouzy/workout-cool?lang=fr">français</a> | 
-  <a href="https://readme-i18n.com/Snouzy/workout-cool?lang=ja">日本語</a> | 
-  <a href="https://readme-i18n.com/Snouzy/workout-cool?lang=ko">한국어</a> | 
-  <a href="https://readme-i18n.com/Snouzy/workout-cool?lang=pt">Português</a> | 
-  <a href="https://readme-i18n.com/Snouzy/workout-cool?lang=ru">Русский</a> | 
+  <a href="https://readme-i18n.com/Snouzy/workout-cool?lang=de">Deutsch</a> |
+  <a href="https://readme-i18n.com/Snouzy/workout-cool?lang=es">Español</a> |
+  <a href="https://readme-i18n.com/Snouzy/workout-cool?lang=fr">français</a> |
+  <a href="https://readme-i18n.com/Snouzy/workout-cool?lang=ja">日本語</a> |
+  <a href="https://readme-i18n.com/Snouzy/workout-cool?lang=ko">한국어</a> |
+  <a href="https://readme-i18n.com/Snouzy/workout-cool?lang=pt">Português</a> |
+  <a href="https://readme-i18n.com/Snouzy/workout-cool?lang=ru">Русский</a> |
   <a href="https://readme-i18n.com/Snouzy/workout-cool?lang=zh">中文</a>
 </p>
 </div>
@@ -39,7 +39,6 @@
 - [Quick Start](#quick-start)
 - [Exercise Database Import](#exercise-database-import)
 - [Project Architecture](#project-architecture)
-- [Roadmap](#roadmap)
 - [Contributing](#contributing)
 - [Self-hosting](#deployment--self-hosting)
 - [Resources](#resources)


### PR DESCRIPTION
## 📝 Description

Remove unlinked `roadmap` from table of contents

