### PR TITLE
feat(ci): multi architecture docker image builds

### DIFF
--- a/.github/workflows/publish-ghcr-image.yml
+++ b/.github/workflows/publish-ghcr-image.yml
@@ -40,14 +40,14 @@ jobs:
             echo "tag=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build Docker image
-        run: |
-          docker build --no-cache . \
-                    --tag ghcr.io/snouzy/workout-cool:${{ steps.vars.outputs.tag }} \
-                    --tag ghcr.io/snouzy/workout-cool:latest
-
-      - name: Push Docker image (release tag)
-        run: docker push ghcr.io/snouzy/workout-cool:${{ steps.vars.outputs.tag }}
-
-      - name: Push Docker image (latest tag)
-        run: docker push ghcr.io/snouzy/workout-cool:latest
+      - name: Build and Push Multi-arch Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/snouzy/workout-cool:${{ steps.vars.outputs.tag }}
+            ghcr.io/snouzy/workout-cool:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## 📝 Description

This PR updates our Docker image publishing workflow, enabling building and pushing multi-architecture images (like `amd64` and `arm64`) to GitHub Container Registry (GHCR).

I've swapped docker build for [Buildx](https://docs.docker.com/build/buildx/) using [docker/setup-buildx-action]( https://github.com/docker/setup-buildx-action) and [docker/build-push-action](https://github.com/docker/build-push-action), which also adds caching for faster builds. 


## 🔗 Related Issues

#155 
