### PR TITLE
fix(ci): change docker buildx driver

### DIFF
--- a/.github/workflows/publish-ghcr-image.yml
+++ b/.github/workflows/publish-ghcr-image.yml
@@ -20,6 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+          install: true
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## 📝 Description

The docker driver (Buildx's default) doesn't support GitHub Actions cache (type=gha). To enable we need to setup docker buildx with `docker-container` driver.

