### PR TITLE
ci: remove unsupported arm v7

### DIFF
--- a/.github/workflows/publish-ghcr-image.yml
+++ b/.github/workflows/publish-ghcr-image.yml
@@ -52,4 +52,4 @@ jobs:
           tags: |
             ghcr.io/snouzy/workout-cool:${{ steps.vars.outputs.tag }}
             ghcr.io/snouzy/workout-cool:latest
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## 📝 Description

Removing `linux/arm/v7` from multi architecture targets since `prisma` seems to only support Linux on x86_64 (AMD64) and ARM64 (aarch64) 

Reference in official prisma documentation [prisma system requirements](https://www.prisma.io/docs/orm/reference/system-requirements)
