### PR TITLE
feat/workout-streak-header: Added squares, but without tooltip

### DIFF
--- a/src/features/layout/Header.tsx
+++ b/src/features/layout/Header.tsx
@@ -12,6 +12,7 @@ import { ReleaseNotesDialog } from "@/features/release-notes";
 import { useLogout } from "@/features/auth/model/useLogout";
 import { useSession } from "@/features/auth/lib/auth-client";
 import { Link } from "@/components/ui/link";
+import WorkoutStreakHeader from "@/features/layout/workout-streak-header";
 
 export const Header = () => {
   const session = useSession();
@@ -60,6 +61,7 @@ export const Header = () => {
 
       {/* User Menu */}
       <div className="navbar-end">
+        <WorkoutStreakHeader className="hidden sm:flex gap-2 mr-2" />
         <div className="tooltip tooltip-bottom" data-tip={t("commons.home")}>
           <Link
             aria-label={t("commons.home")}

--- a/src/features/layout/workout-streak-header.tsx
+++ b/src/features/layout/workout-streak-header.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState, useMemo } from "react";
+import type { WorkoutSession } from "@/shared/lib/workout-session/types/workout-session";
+import { workoutSessionLocal } from "@/shared/lib/workout-session/workout-session.local";
+import dayjs from "dayjs";
+
+interface WorkoutSessionProps {
+  streakCount?: number;
+  className?: string;
+}
+
+export default function WorkoutStreakHeader({ streakCount = 5, className }: WorkoutSessionProps) {
+  const [sessions, setSessions] = useState<WorkoutSession[] | null>(null);
+
+  const recentSessions = useMemo(() => {
+    const recentSessions =
+      sessions?.filter((s) => {
+        const endDate = dayjs(s.endedAt).toDate();
+        const cutoffDate = dayjs().subtract(streakCount, "day").toDate();
+        return endDate > cutoffDate;
+      }) ?? [];
+
+    // Sorted from oldest to most recent
+    recentSessions.sort((a, b) => dayjs(a.endedAt).diff(dayjs(b.endedAt)));
+    return recentSessions;
+  }, [sessions, streakCount]);
+
+  const squares = useMemo<(WorkoutSession | null)[]>(() => {
+    return [...Array(streakCount)].map((_, i) => {
+      const targetDate = dayjs()
+        .subtract(streakCount - 1 - i, "day")
+        .startOf("day");
+
+      // Choose most recent from that day
+      return recentSessions.findLast((session) => dayjs(session.endedAt).isSame(targetDate, "day")) || null;
+    });
+  }, [recentSessions, streakCount]);
+
+  useEffect(() => {
+    const sessions = workoutSessionLocal.getAll();
+    setSessions(sessions);
+  }, []);
+
+  return (
+    <div className={className}>
+      {squares.map((session, i) => (
+        <div key={i} className={`w-5 h-5 rounded-md ${session ? "bg-green-500" : "bg-gray-300 border border-gray-400"}`} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## 📝 Description

<!-- Briefly describe the changes made -->
I added a 5 day streak header that allows users to track consistency over the last 5 days

## 📋 Checklist

- [x] My code follows the project conventions
- [ ] This PR includes breaking changes
- [x] I have updated documentation if necessary

## 🗃️ Prisma Migrations (if applicable)

- [ ] I have created a migration
- [ ] I have tested the migration locally

## 📸 Screenshots (if applicable)

<!-- Add screenshots for visual changes -->
<img width="582" height="124" alt="image" src="https://github.com/user-attachments/assets/88da3085-49fb-4dbc-8e87-8b47bd1be48a" />


## 🔗 Related Issues

<!-- Reference issues: Closes #123, Fixes #456 -->
https://github.com/Snouzy/workout-cool/issues/53
