### PR TITLE
Update .env.example: fix miss-match between database name in  POSTGRES_DB and DATABASE_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ POSTGRES_DB=workout-cool
 DB_HOST=localhost
 DB_PORT=5432
 # Format: postgresql://USER:PASSWORD@HOST:PORT/DATABASE
-DATABASE_URL=postgresql://username:password@localhost:5432/workout_cool
+DATABASE_URL=postgresql://username:password@localhost:5432/workout-cool
 
 # Authentication
 # The URL where your application is running


### PR DESCRIPTION
fix miss-match between database name in  POSTGRES_DB and DATABASE_URL

## 📝 Description

<!-- Briefly describe the changes made -->

## 📋 Checklist

- [x] My code follows the project conventions
- [ ] This PR includes breaking changes
- [x] I have updated documentation if necessary

## 🗃️ Prisma Migrations (if applicable)

- [ ] I have created a migration
- [ ] I have tested the migration locally

## 📸 Screenshots (if applicable)

<!-- Add screenshots for visual changes -->

## 🔗 Related Issues
https://github.com/Snouzy/workout-cool/issues/164#issue-3261208973
```

$ make dev
docker compose up -d postgres
[+] Running 2/2
 ✔ Volume "workout-cool_pgdata"       Created                                                                                                                                                                                                              0.0s
 ✔ Container workout-cool-postgres-1  Started                                                                                                                                                                                                              0.3s
pnpm install --frozen-lockfile
Lockfile is up to date, resolution step is skipped
Already up to date

╭ Warning ───────────────────────────────────────────────────────────────────────────────────╮
│                                                                                            │
│   Ignored build scripts: @prisma/client, @prisma/engines, prisma, unrs-resolver.           │
│   Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.   │
│                                                                                            │
╰────────────────────────────────────────────────────────────────────────────────────────────╯

> workoutcool@1.3.0 postinstall ~/github.com/workout-cool
> prisma generate

Environment variables loaded from .env
Prisma schema loaded from prisma/schema.prisma

✔ Generated Prisma Client (v6.10.1) to ./node_modules/.pnpm/@prisma+client@6.10.1_prisma@6.10.1_typescript@5.8.3__typescript@5.8.3/node_modules/@prisma/client in 77ms

Start by importing your Prisma Client (See: https://pris.ly/d/importing-client)

Tip: Want to turn off tips and other hints? https://pris.ly/tip-4-nohints


Done in 1.1s using pnpm v10.12.1
npx prisma migrate deploy
Environment variables loaded from .env
Prisma schema loaded from prisma/schema.prisma
Datasource "db": PostgreSQL database "workout_cool", schema "public" at "localhost:5432"

Error: P1001: Can't reach database server at `localhost:5432`

Please make sure your database server is running at `localhost:5432`.
make: *** [db-migrate] Error 1



$ docker logs workout-cool-postgres-1
The files belonging to this database system will be owned by user "postgres".
This user must also own the server process.

The database cluster will be initialized with locale "en_US.utf8".
The default database encoding has accordingly been set to "UTF8".
The default text search configuration will be set to "english".

Data page checksums are disabled.

fixing permissions on existing directory /var/lib/postgresql/data ... ok
creating subdirectories ... ok
selecting dynamic shared memory implementation ... posix
selecting default max_connections ... 100
selecting default shared_buffers ... 128MB
selecting default time zone ... Etc/UTC
creating configuration files ... ok
running bootstrap script ... ok
performing post-bootstrap initialization ... ok
syncing data to disk ... ok


Success. You can now start the database server using:

    pg_ctl -D /var/lib/postgresql/data -l logfile start

initdb: warning: enabling "trust" authentication for local connections
initdb: hint: You can change this by editing pg_hba.conf or using the option -A, or --auth-local and --auth-host, the next time you run initdb.
waiting for server to start....2025-07-24 20:24:30.602 UTC [47] LOG:  starting PostgreSQL 15.13 (Debian 15.13-1.pgdg120+1) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
2025-07-24 20:24:30.603 UTC [47] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2025-07-24 20:24:30.605 UTC [50] LOG:  database system was shut down at 2025-07-24 20:24:30 UTC
2025-07-24 20:24:30.607 UTC [47] LOG:  database system is ready to accept connections
 done
server started
CREATE DATABASE


/usr/local/bin/docker-entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*

waiting for server to shut down...2025-07-24 20:24:30.744 UTC [47] LOG:  received fast shutdown request
.2025-07-24 20:24:30.744 UTC [47] LOG:  aborting any active transactions
2025-07-24 20:24:30.746 UTC [47] LOG:  background worker "logical replication launcher" (PID 53) exited with exit code 1
2025-07-24 20:24:30.746 UTC [48] LOG:  shutting down
2025-07-24 20:24:30.746 UTC [48] LOG:  checkpoint starting: shutdown immediate
2025-07-24 20:24:30.770 UTC [48] LOG:  checkpoint complete: wrote 918 buffers (5.6%); 0 WAL file(s) added, 0 removed, 0 recycled; write=0.010 s, sync=0.012 s, total=0.024 s; sync files=301, longest=0.004 s, average=0.001 s; distance=4222 kB, estimate=4222 kB
2025-07-24 20:24:30.772 UTC [47] LOG:  database system is shut down
 done
server stopped

PostgreSQL init process complete; ready for start up.

2025-07-24 20:24:30.855 UTC [1] LOG:  starting PostgreSQL 15.13 (Debian 15.13-1.pgdg120+1) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
2025-07-24 20:24:30.855 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
2025-07-24 20:24:30.855 UTC [1] LOG:  listening on IPv6 address "::", port 5432
2025-07-24 20:24:30.856 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2025-07-24 20:24:30.858 UTC [63] LOG:  database system was shut down at 2025-07-24 20:24:30 UTC
2025-07-24 20:24:30.859 UTC [1] LOG:  database system is ready to accept connections
2025-07-24 20:24:32.076 UTC [67] FATAL:  database "workout_cool" does not exist
```
<!-- Reference issues: Closes #123, Fixes #456 -->
