### PR TITLE
fix: docker scripts path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,9 +9,9 @@ DATABASE_URL=postgresql://username:password@localhost:5432/workout-cool
 
 # Authentication
 # The URL where your application is running
-BETTER_AUTH_URL="http://localhost:3000"
+BETTER_AUTH_URL=http://localhost:3000
 # Generate a secure random string using: openssl rand -base64 32
-BETTER_AUTH_SECRET="your-secret-key-here"
+BETTER_AUTH_SECRET=your-secret-key-here
 
 # Google OAuth
 # Get these from Google Cloud Console: https://console.cloud.google.com
@@ -26,7 +26,7 @@ NEXT_PUBLIC_OPENPANEL_CLIENT_ID=
 
 # Environment
 # Options: development, production, test
-NODE_ENV="development"
+NODE_ENV=development
 
 #SMTP Configuration
 # Using MailHog for example. https://github.com/mailhog/MailHog
@@ -74,4 +74,4 @@ REVENUECAT_SECRET_KEY="test_secret_key"
 # Options: DISABLED, LICENSE_KEY, SUBSCRIPTION, FREEMIUM
 DEFAULT_BILLING_MODE="DISABLED"
 
-NEXT_PUBLIC_APP_URL="http://localhost:3000"
+NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,10 @@ COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/prisma ./prisma
 COPY --from=builder /app/data ./data
 
-COPY scripts /app
-RUN chmod +x /app/setup.sh
+COPY scripts /app/scripts
+RUN chmod +x /app/scripts/setup.sh
 
-ENTRYPOINT ["/app/setup.sh"]
+ENTRYPOINT ["/app/scripts/setup.sh"]
 
 EXPOSE 3000
 ENV PORT=3000

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -10,7 +10,7 @@ if [ "$SEED_SAMPLE_DATA" = "true"  ]; then
   echo "Seed sample data enabled, importing sample data..."
     # Import exercises if CSV exists
     if [ -f "./data/sample-exercises.csv" ]; then
-        npx tsx import-exercises-with-attributes.ts ./data/sample-exercises.csv
+        npx tsx scripts/import-exercises-with-attributes.ts ./data/sample-exercises.csv
     else
         echo "No exercises sample data found, skipping import."
     fi


### PR DESCRIPTION
## 📝 Description

Fixed Docker script path resolution issue preventing exercise import functionality from working in containerized environments.

**Problem:** Docker build was successful and WebUI was accessible, but running exercise import commands failed with `Cannot find module '/app/scripts/import-exercises-with-attributes.ts' error.`

**Root Cause:** Dockerfile was copying scripts to incorrect directory structure, copying contents of `scripts/` directly to `/app/` instead of maintaining the `/app/scripts/` directory structure expected by the application.

**Changes Made**
  - [x] Updated `Dockerfile` to copy scripts to proper /`app/scripts/` directory
  - [x] Fixed `ENTRYPOINT` path to use `/app/scripts/setup.sh`
  - [x] Updated `setup.sh` to reference correct script path

## 📋 Checklist

- [x] My code follows the project conventions
- [ ] This PR includes breaking changes
- [ ] I have updated documentation if necessary

## 📸 Screenshots (if applicable)

<img width="568" height="725" alt="Screenshot 2025-08-20 at 18 51 08" src="https://github.com/user-attachments/assets/82029750-5d57-4870-acd5-c7beedfaa896" />

## 🔗 Related Issues

  Closes #168

  Testing:
  - ✅ Docker container builds successfully
  - ✅ Exercise import scripts execute without module resolution errors
  - ✅ pnpm run import:exercises-full ./data/sample-exercises.csv works in Docker
