### PR TITLE
fix(prisma): add migration for user onboardingPreferences

### DIFF
--- a/prisma/migrations/20260616145902_add_user_onboarding_preferences/migration.sql
+++ b/prisma/migrations/20260616145902_add_user_onboarding_preferences/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user" ADD COLUMN     "onboardingPreferences" JSONB;


### PR DESCRIPTION
## 📝 Description

This PR adds the missing Prisma migration for `user.onboardingPreferences`, which was causing `make dev` to fail during `db:seed-leaderboard` with Prisma error `P2022`.

The schema already referenced `onboardingPreferences`, but the column was not present in the active database migration history. This change creates the missing JSONB column so leaderboard seeding can complete successfully.

## 📋 Checklist

- [x] My code follows the project conventions
- [ ] This PR includes breaking changes
- [x] I have updated documentation if necessary

## 🗃️ Prisma Migrations (if applicable)

- [x] I have created a migration
- [x] I have tested the migration locally

## 📸 Screenshots (if applicable)

N/A

## 🔗 Related Issues

Closes #208