### PR TITLE
fix(import): accept documented exercise CSV aliases

### DIFF
--- a/scripts/import-exercise-attribute-values.test.ts
+++ b/scripts/import-exercise-attribute-values.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for normalizeExerciseAttributeValue.
+ *
+ * Run with:
+ *   pnpm exec tsx scripts/import-exercise-attribute-values.test.ts
+ */
+
+import assert from "node:assert/strict";
+
+import { normalizeExerciseAttributeValue } from "./import-exercise-attribute-values";
+
+// -- PRIMARY_MUSCLE -----------------------------------------------------------
+
+assert.equal(
+  normalizeExerciseAttributeValue("PRIMARY_MUSCLE", "CORE"),
+  "ABDOMINALS",
+  "PRIMARY_MUSCLE CORE -> ABDOMINALS"
+);
+
+// -- SECONDARY_MUSCLE (lowercase input) ---------------------------------------
+
+assert.equal(
+  normalizeExerciseAttributeValue("SECONDARY_MUSCLE", "core"),
+  "ABDOMINALS",
+  "SECONDARY_MUSCLE core -> ABDOMINALS"
+);
+
+// -- EQUIPMENT ----------------------------------------------------------------
+
+assert.equal(
+  normalizeExerciseAttributeValue("EQUIPMENT", "BODYWEIGHT"),
+  "BODY_ONLY",
+  "EQUIPMENT BODYWEIGHT -> BODY_ONLY"
+);
+
+assert.equal(
+  normalizeExerciseAttributeValue("EQUIPMENT", "RESISTANCE_BAND"),
+  "BANDS",
+  "EQUIPMENT RESISTANCE_BAND -> BANDS"
+);
+
+// -- TYPE ---------------------------------------------------------------------
+
+assert.equal(
+  normalizeExerciseAttributeValue("TYPE", "FLEXIBILITY"),
+  "STRETCHING",
+  "TYPE FLEXIBILITY -> STRETCHING"
+);
+
+// -- N/A-like values ----------------------------------------------------------
+
+for (const naLike of ["N/A", "n/a", "NA", "na", "", "none", "None", "NONE"]) {
+  assert.equal(
+    normalizeExerciseAttributeValue("PRIMARY_MUSCLE", naLike),
+    "NA",
+    `N/A-like value "${naLike}" -> NA`
+  );
+}
+
+// -- Unknown values must throw ------------------------------------------------
+
+assert.throws(
+  () => normalizeExerciseAttributeValue("EQUIPMENT", "MAGIC_CARPET"),
+  (err: unknown) => {
+    assert(err instanceof Error, "should throw an Error");
+    assert(
+      err.message.includes("EQUIPMENT"),
+      `error message should include attribute name "EQUIPMENT", got: ${err.message}`
+    );
+    assert(
+      err.message.includes("MAGIC_CARPET"),
+      `error message should include bad value "MAGIC_CARPET", got: ${err.message}`
+    );
+    return true;
+  },
+  "unknown EQUIPMENT value should throw with attribute name and bad value"
+);
+
+assert.throws(
+  () => normalizeExerciseAttributeValue("TYPE", "DANCE_PARTY"),
+  (err: unknown) => {
+    assert(err instanceof Error, "should throw an Error");
+    assert(err.message.includes("TYPE"), `error should mention "TYPE", got: ${err.message}`);
+    assert(err.message.includes("DANCE_PARTY"), `error should mention "DANCE_PARTY", got: ${err.message}`);
+    return true;
+  },
+  "unknown TYPE value should throw with attribute name and bad value"
+);
+
+console.log("All assertions passed.");

--- a/scripts/import-exercise-attribute-values.ts
+++ b/scripts/import-exercise-attribute-values.ts
@@ -1,0 +1,111 @@
+/**
+ * import-exercise-attribute-values.ts
+ *
+ * Normalizes raw CSV attribute values into valid ExerciseAttributeValueEnum
+ * strings.  Import this module from the exercise import scripts to keep
+ * normalization logic in one place.
+ *
+ * Usage:
+ *   import { normalizeExerciseAttributeValue } from "./import-exercise-attribute-values";
+ *   const value = normalizeExerciseAttributeValue("EQUIPMENT", "BODYWEIGHT"); // "BODY_ONLY"
+ */
+
+import { ExerciseAttributeValueEnum } from "@prisma/client";
+
+/** Values that mean "not applicable / unknown" in a CSV. */
+const NA_LIKE = new Set(["N/A", "NA", "NONE", "NULL", ""]);
+
+/**
+ * Per-attribute alias map.
+ * Keys are the normalised (trimmed + uppercased) CSV value.
+ * Values are the canonical ExerciseAttributeValueEnum string.
+ */
+const ALIASES: Record<string, Record<string, string>> = {
+  PRIMARY_MUSCLE: {
+    CORE: "ABDOMINALS",
+  },
+  SECONDARY_MUSCLE: {
+    CORE: "ABDOMINALS",
+  },
+  EQUIPMENT: {
+    BODYWEIGHT: "BODY_ONLY",
+    RESISTANCE_BAND: "BANDS",
+  },
+  TYPE: {
+    FLEXIBILITY: "STRETCHING",
+  },
+};
+
+/** All valid enum values as a Set for O(1) lookup. */
+const VALID_VALUES = new Set<string>(Object.values(ExerciseAttributeValueEnum) as string[]);
+
+/**
+ * A short list of canonical examples shown in error messages so contributors
+ * can quickly pick a supported value.
+ */
+const ATTRIBUTE_EXAMPLES: Record<string, string> = {
+  PRIMARY_MUSCLE: "ABDOMINALS, BICEPS, CHEST, QUADRICEPS, GLUTES",
+  SECONDARY_MUSCLE: "ABDOMINALS, TRICEPS, HAMSTRINGS, LATS",
+  EQUIPMENT: "BODY_ONLY, BARBELL, DUMBBELL, BANDS, MACHINE, CABLE",
+  TYPE: "STRENGTH, CARDIO, STRETCHING, PLYOMETRICS, POWERLIFTING",
+  MECHANICS_TYPE: "COMPOUND, ISOLATION",
+};
+
+/**
+ * Normalises a raw CSV attribute value for the given attribute name.
+ *
+ * Steps:
+ *  1. Trim whitespace and uppercase.
+ *  2. If the result is N/A-like (N/A, NA, NONE, NULL, empty) return "NA".
+ *  3. Apply attribute-aware aliases (e.g. CORE -> ABDOMINALS for muscles).
+ *  4. Accept any value that is already a valid ExerciseAttributeValueEnum.
+ *  5. Otherwise throw a descriptive Error.
+ *
+ * @param attributeName - e.g. "PRIMARY_MUSCLE", "EQUIPMENT", "TYPE"
+ * @param value         - raw string from the CSV cell
+ * @returns A string that is a valid ExerciseAttributeValueEnum member
+ * @throws Error when the value cannot be mapped to a valid enum member
+ */
+export function normalizeExerciseAttributeValue(
+  attributeName: string,
+  value: string,
+): string {
+  const normalised = value.trim().toUpperCase();
+
+  // Step 1: N/A-like values
+  if (NA_LIKE.has(normalised)) {
+    return "NA" as ExerciseAttributeValueEnum;
+  }
+
+  // Step 2: attribute-aware alias lookup
+  const attrAliases = ALIASES[attributeName.trim().toUpperCase()] ?? {};
+  const aliased = attrAliases[normalised];
+  if (aliased !== undefined) {
+    return aliased as ExerciseAttributeValueEnum;
+  }
+
+  // Step 3: already a valid enum value
+  if (VALID_VALUES.has(normalised)) {
+    return normalised as ExerciseAttributeValueEnum;
+  }
+
+  // Step 4: nothing matched - emit a helpful error
+  const examples = ATTRIBUTE_EXAMPLES[attributeName.toUpperCase()];
+  const hint = examples
+    ? `  Accepted examples for ${attributeName}: ${examples}.`
+    : "  Check the ExerciseAttributeValueEnum in prisma/schema.prisma for valid values.";
+
+  // Also mention known aliases for this attribute
+  const knownAliases = Object.entries(attrAliases);
+  const aliasHint =
+    knownAliases.length > 0
+      ? `\n  Accepted aliases for ${attributeName}: ${knownAliases.map(([k, v]) => `${k} -> ${v}`).join(", ")}.`
+      : "";
+
+  throw new Error(
+    `[import-exercises] Unknown value "${normalised}" for attribute "${attributeName}".\n` +
+      hint +
+      aliasHint +
+      "\n  N/A-like values (N/A, NA, NONE, NULL, empty string) are mapped to NA automatically.",
+  );
+}

--- a/scripts/import-exercises-with-attributes.prompt.md
+++ b/scripts/import-exercises-with-attributes.prompt.md
@@ -5,23 +5,35 @@ Generate 50 unique fitness exercises in CSV format with the following columns:
 ## Requirements:
 
 - Each exercise should have multiple rows (one per attribute)
-- Use REALISTICS YouTube URLs for videos (format: https://www.youtube.com/watch?v=VIDEO_ID) from
+- Use REALISTIC YouTube URLs for videos (format: https://www.youtube.com/watch?v=VIDEO_ID) from
   @https://www.youtube.com/@fit-distance/videos
 - Use corresponding thumbnail URLs (format: https://img.youtube.com/vi/VIDEO_ID/maxresdefault.jpg)
 - Include HTML tags in descriptions (like <p>, <strong>, <em>)
 - Create slugs in kebab-case format
 
-Use these attribute types and ONLY these: `TYPE`: `STRENGTH, CARDIO, PLYOMETRICS, STRETCHING, FLEXIBILITY, POWERLIFTING` `PRIMARY_MUSCLE`:
-`QUADRICEPS, CHEST, BACK, SHOULDERS, BICEPS, TRICEPS, HAMSTRINGS, GLUTES, CALVES, CORE, FOREARMS` `SECONDARY_MUSCLE`:
-`QUADRICEPS, CHEST, BACK, SHOULDERS, BICEPS, TRICEPS, HAMSTRINGS, GLUTES, CALVES, CORE, FOREARMS` `EQUIPMENT`:
-`BARBELL, DUMBBELL, BODYWEIGHT, MACHINE, CABLE, RESISTANCE_BAND, KETTLEBELLS, MEDICINE_BALL` `MECHANICS_TYPE`: `COMPOUND, ISOLATION`
+## Attribute values (use EXACTLY these values in the CSV):
+
+`TYPE`: `STRENGTH, CARDIO, PLYOMETRICS, STRETCHING, POWERLIFTING, WEIGHTLIFTING, CROSSFIT, STABILIZATION`
+  - Alias accepted by the importer: FLEXIBILITY -> STRETCHING (prefer STRETCHING directly)
+
+`PRIMARY_MUSCLE`: `QUADRICEPS, CHEST, BACK, SHOULDERS, BICEPS, TRICEPS, HAMSTRINGS, GLUTES, CALVES, ABDOMINALS, FOREARMS, LATS, TRAPS, OBLIQUES`
+  - Alias accepted by the importer: CORE -> ABDOMINALS (prefer ABDOMINALS directly)
+
+`SECONDARY_MUSCLE`: same list as PRIMARY_MUSCLE
+  - Alias accepted by the importer: CORE -> ABDOMINALS (prefer ABDOMINALS directly)
+
+`EQUIPMENT`: `BARBELL, DUMBBELL, BODY_ONLY, MACHINE, CABLE, BANDS, KETTLEBELLS, MEDICINE_BALL, PULLUP_BAR, BENCH, TRX, SWISS_BALL, FOAM_ROLL`
+  - Alias accepted by the importer: BODYWEIGHT -> BODY_ONLY, RESISTANCE_BAND -> BANDS (prefer BODY_ONLY / BANDS directly)
+
+`MECHANICS_TYPE`: `COMPOUND, ISOLATION`
+
+Use `NA` for any attribute that does not apply to an exercise.
 
 ## Example format:
 
-1,"Squat avec barre","Barbell Squat","<p>Placez la barre...</p>","<p>Place the
-barbell...</p>",https://www.youtube.com/watch?v=abc123,https://img.youtube.com/vi/abc123/maxresdefault.jpg,"Introduction courte","Short
-introduction","squat-avec-barre","barbell-squat",TYPE,STRENGTH 1,"Squat avec barre","Barbell Squat","<p>Placez la barre...</p>","<p>Place
-the barbell...</p>",https://www.youtube.com/watch?v=abc123,https://img.youtube.com/vi/abc123/maxresdefault.jpg,"Introduction courte","Short
-introduction","squat-avec-barre","barbell-squat",PRIMARY_MUSCLE,QUADRICEPS
+1,"Squat avec barre","Barbell Squat","<p>Placez la barre...</p>","<p>Place the barbell...</p>",https://www.youtube.com/watch?v=abc123,https://img.youtube.com/vi/abc123/maxresdefault.jpg,"Introduction courte","Short introduction","squat-avec-barre","barbell-squat",TYPE,STRENGTH
+1,"Squat avec barre","Barbell Squat","<p>Placez la barre...</p>","<p>Place the barbell...</p>",https://www.youtube.com/watch?v=abc123,https://img.youtube.com/vi/abc123/maxresdefault.jpg,"Introduction courte","Short introduction","squat-avec-barre","barbell-squat",PRIMARY_MUSCLE,QUADRICEPS
+1,"Squat avec barre","Barbell Squat","<p>Placez la barre...</p>","<p>Place the barbell...</p>",https://www.youtube.com/watch?v=abc123,https://img.youtube.com/vi/abc123/maxresdefault.jpg,"Introduction courte","Short introduction","squat-avec-barre","barbell-squat",EQUIPMENT,BARBELL
+1,"Squat avec barre","Barbell Squat","<p>Placez la barre...</p>","<p>Place the barbell...</p>",https://www.youtube.com/watch?v=abc123,https://img.youtube.com/vi/abc123/maxresdefault.jpg,"Introduction courte","Short introduction","squat-avec-barre","barbell-squat",MECHANICS_TYPE,COMPOUND
 
 Reply only with the csv.

--- a/scripts/import-exercises-with-attributes.ts
+++ b/scripts/import-exercises-with-attributes.ts
@@ -4,6 +4,8 @@ import fs from "fs";
 import csv from "csv-parser";
 import { ExerciseAttributeNameEnum, ExerciseAttributeValueEnum, PrismaClient } from "@prisma/client";
 
+import { normalizeExerciseAttributeValue } from "./import-exercise-attribute-values";
+
 const prisma = new PrismaClient();
 
 interface ExerciseAttributeCSVRow {
@@ -76,14 +78,8 @@ async function ensureAttributeNameExists(name: ExerciseAttributeNameEnum) {
   return attributeName;
 }
 
-function normalizeAttributeValue(value: string): ExerciseAttributeValueEnum {
-  const cleaned = value.trim().toUpperCase();
-  if (["N/A", "NA", "NONE", "NULL", ""].includes(cleaned)) return "NA";
-  if ((Object.values(ExerciseAttributeValueEnum) as string[]).includes(cleaned)) {
-    return cleaned as ExerciseAttributeValueEnum;
-  }
-  throw new Error(`Unknown attribute value: ${value}`);
-}
+// Value normalisation is handled by the shared helper module.
+// See ./import-exercise-attribute-values.ts for alias definitions and error details.
 
 async function ensureAttributeValueExists(attributeNameId: string, value: ExerciseAttributeValueEnum) {
   let attributeValue = await prisma.exerciseAttributeValue.findFirst({
@@ -164,8 +160,17 @@ async function importExercisesFromCSV(filePath: string) {
               // Create new attributes
               for (const attr of exercise.attributes) {
                 try {
-                  const attributeName = await ensureAttributeNameExists(attr.attributeName);
-                  const attributeValue = await ensureAttributeValueExists(attributeName.id, normalizeAttributeValue(attr.attributeValue));
+                  const normalised = normalizeExerciseAttributeValue(
+                    attr.attributeName,
+                    attr.attributeValue,
+                  );
+                  const attributeName = await ensureAttributeNameExists(
+                    attr.attributeName as ExerciseAttributeNameEnum,
+                  );
+                  const attributeValue = await ensureAttributeValueExists(
+                    attributeName.id,
+                    normalised as ExerciseAttributeValueEnum,
+                  );
 
                   await prisma.exerciseAttribute.create({
                     data: {
@@ -175,9 +180,17 @@ async function importExercisesFromCSV(filePath: string) {
                     },
                   });
 
-                  console.log(`   ✅ Attribute: ${attr.attributeName} = ${attr.attributeValue}`);
+                  console.log(
+                    `   [OK] Attribute: ${attr.attributeName} = ${attr.attributeValue}` +
+                      (normalised !== attr.attributeValue.trim().toUpperCase()
+                        ? ` (normalised to ${normalised})`
+                        : ""),
+                  );
                 } catch (attrError) {
-                  console.error("   ❌ Attribute error:", attrError);
+                  console.error(
+                    `   [ERROR] Attribute ${attr.attributeName}=${attr.attributeValue}:`,
+                    attrError instanceof Error ? attrError.message : attrError,
+                  );
                 }
               }
 


### PR DESCRIPTION
## Summary

Fixes #167 by making the exercise CSV importer accept the values already documented in the CSV generation prompt.

## What changed

- Added `normalizeExerciseAttributeValue(attributeName, value)` for importer-safe attribute value normalization.
- Added attribute-aware aliases:
  - `PRIMARY_MUSCLE` / `SECONDARY_MUSCLE`: `CORE -> ABDOMINALS`
  - `EQUIPMENT`: `BODYWEIGHT -> BODY_ONLY`
  - `EQUIPMENT`: `RESISTANCE_BAND -> BANDS`
  - `TYPE`: `FLEXIBILITY -> STRETCHING`
- Kept existing N/A-like handling (`N/A`, `NA`, `NONE`, `NULL`, empty string -> `NA`).
- Improved unknown attribute value errors so the log includes the attribute name, bad value, and useful examples.
- Updated the CSV generation prompt to prefer canonical schema values while documenting accepted aliases.
- Added a focused assertion script for the normalization behavior.

## Why

The CSV prompt previously told users or LLMs to generate values like `CORE`, but `ExerciseAttributeValueEnum` uses `ABDOMINALS`. That mismatch makes self-hosted custom exercise imports fail or silently lose useful muscle attributes.

## Testing

Passed:

- `pnpm exec tsx scripts/import-exercise-attribute-values.test.ts`
- `pnpm exec eslint scripts/import-exercise-attribute-values.ts scripts/import-exercise-attribute-values.test.ts scripts/import-exercises-with-attributes.ts`
- `git diff --check HEAD~1 HEAD`

Checked but not clean on current base:

- `pnpm exec tsc --noEmit --pretty false` fails on existing public image module imports such as `@public/logo.png`, `@public/images/trophy.png`, and equipment images.
- `pnpm lint` fails on existing unrelated import/order and unused React warnings/errors across the app. The files touched by this PR pass the targeted ESLint command above.

Not run:

- Full CSV import against PostgreSQL. The importer requires a configured `DATABASE_URL`; this PR verifies the normalization layer directly and keeps database behavior unchanged.