### PR TITLE
fix(leaderboard): exclude incomplete sessions from counts

### DIFF
--- a/src/features/leaderboard/actions/get-top-workout-users.action.ts
+++ b/src/features/leaderboard/actions/get-top-workout-users.action.ts
@@ -22,16 +22,14 @@ export const getTopWorkoutUsersAction = actionClient.schema(inputSchema).action(
   try {
     const { startDate, endDate } = getDateRangeForPeriod(period);
 
+    // Only count sessions that were actually finished (endedAt is set).
+    const sessionWhere = startDate
+      ? { startedAt: { gte: startDate, lte: endDate }, endedAt: { not: null } }
+      : { endedAt: { not: null } };
+
     const whereClause = {
       WorkoutSession: {
-        some: startDate
-          ? {
-              startedAt: {
-                gte: startDate,
-                lte: endDate,
-              },
-            }
-          : {},
+        some: sessionWhere,
       },
     };
 
@@ -45,27 +43,13 @@ export const getTopWorkoutUsersAction = actionClient.schema(inputSchema).action(
         createdAt: true,
         _count: {
           select: {
-            WorkoutSession: startDate
-              ? {
-                  where: {
-                    startedAt: {
-                      gte: startDate,
-                      lte: endDate,
-                    },
-                  },
-                }
-              : true,
+            WorkoutSession: {
+              where: sessionWhere,
+            },
           },
         },
         WorkoutSession: {
-          where: startDate
-            ? {
-                startedAt: {
-                  gte: startDate,
-                  lte: endDate,
-                },
-              }
-            : undefined,
+          where: sessionWhere,
           select: {
             endedAt: true,
             startedAt: true,

--- a/src/features/leaderboard/actions/get-user-position.action.ts
+++ b/src/features/leaderboard/actions/get-user-position.action.ts
@@ -17,63 +17,31 @@ export const getUserPositionAction = actionClient.schema(inputSchema).action(asy
   try {
     const { startDate, endDate } = getDateRangeForPeriod(period);
 
+    // Only count sessions that were actually finished (endedAt is set).
+    // Sessions that the user started but quit before completing should not
+    // count toward the leaderboard.
+    const dateFilter = startDate
+      ? { startedAt: { gte: startDate, lte: endDate }, endedAt: { not: null } }
+      : { endedAt: { not: null } };
+
     // Get user's workout count
     const userWorkoutCount = await prisma.workoutSession.count({
-      where: {
-        userId,
-        ...(startDate && {
-          startedAt: {
-            gte: startDate,
-            lte: endDate,
-          },
-        }),
-      },
+      where: { userId, ...dateFilter },
     });
 
     // Calculate real position
     const totalUsersWithWorkouts = await prisma.user.count({
-      where: {
-        WorkoutSession: {
-          some: startDate
-            ? {
-                startedAt: {
-                  gte: startDate,
-                  lte: endDate,
-                },
-              }
-            : {},
-        },
-      },
+      where: { WorkoutSession: { some: dateFilter } },
     });
 
     // Get all users sorted by workout count to find exact position
     const allUsers = await prisma.user.findMany({
-      where: {
-        WorkoutSession: {
-          some: startDate
-            ? {
-                startedAt: {
-                  gte: startDate,
-                  lte: endDate,
-                },
-              }
-            : {},
-        },
-      },
+      where: { WorkoutSession: { some: dateFilter } },
       select: {
         id: true,
         _count: {
           select: {
-            WorkoutSession: startDate
-              ? {
-                  where: {
-                    startedAt: {
-                      gte: startDate,
-                      lte: endDate,
-                    },
-                  },
-                }
-              : true,
+            WorkoutSession: { where: dateFilter },
           },
         },
       },


### PR DESCRIPTION
Fixes #211

## Problem

The leaderboard counted workout sessions that were started but never finished (`endedAt: null`). Users who abandoned sessions mid-workout got inflated rankings.

## Changes

Add `endedAt: { not: null }` to all Prisma queries that count sessions in both leaderboard actions. Introduced a shared `dateFilter` / `sessionWhere` object in each action to keep the date-range logic DRY.

### `get-user-position.action.ts`
- `prisma.workoutSession.count` — added `endedAt` filter
- `prisma.user.count` — added `endedAt` filter via `WorkoutSession: { some: dateFilter }`
- `prisma.user.findMany` — same filter on `where`, `_count.WorkoutSession.where`

### `get-top-workout-users.action.ts`
- Extracted `sessionWhere` with `endedAt: { not: null }`
- Applied to `whereClause`, `_count.WorkoutSession.where`, and `WorkoutSession.where`

## Verification

- TypeScript: no new errors
- All session-counting queries now consistently exclude incomplete sessions

## Side effects

Users who previously appeared on the leaderboard with abandoned sessions may see their counts drop slightly — this is the correct behavior (those sessions were never actually completed).