### PR TITLE
fix(workout-session): mark all sets completed on "Finish Session"

### DIFF
--- a/src/features/workout-session/model/workout-session.store.ts
+++ b/src/features/workout-session/model/workout-session.store.ts
@@ -135,7 +135,18 @@ export const useWorkoutSessionStore = create<WorkoutSessionState>((set, get) => 
     const { session } = get();
 
     if (session) {
-      workoutSessionLocal.update(session.id, { status: "completed", endedAt: new Date().toISOString() });
+      // Mark all remaining sets as completed so analytics (volume, ACWR,
+      // exercise completion stats) reflects the work that was actually done.
+      const completedExercises = session.exercises.map((ex) => ({
+        ...ex,
+        sets: ex.sets.map((set) => ({ ...set, completed: true })),
+      }));
+
+      workoutSessionLocal.update(session.id, {
+        status: "completed",
+        endedAt: new Date().toISOString(),
+        exercises: completedExercises,
+      });
       console.log({
         session: { ...session, status: "completed", endedAt: new Date().toISOString() },
         progress: {},
@@ -144,7 +155,12 @@ export const useWorkoutSessionStore = create<WorkoutSessionState>((set, get) => 
         isWorkoutActive: false,
       });
       set({
-        session: { ...session, status: "completed", endedAt: new Date().toISOString() },
+        session: {
+          ...session,
+          exercises: completedExercises,
+          status: "completed",
+          endedAt: new Date().toISOString(),
+        },
         progress: {},
         elapsedTime: 0,
         isTimerRunning: false,


### PR DESCRIPTION
Fixes #212

## Problem

When a user clicks **Finish Session** without first clicking **Finish Set** on every individual set, the session was marked `status: "completed"` with `endedAt` set, but individual sets kept `completed: false`.

This made those sessions invisible to analytics that filter on `set.completed`: volume calculations, ACWR fatigue curves, and exercise completion stats all showed these workouts as if no work was done.

## Changes

In `completeWorkout()` (`src/features/workout-session/model/workout-session.store.ts`), before persisting the session as completed, map over all exercises and sets to set `completed: true` on every set:

```ts
const completedExercises = session.exercises.map((ex) => ({
  ...ex,
  sets: ex.sets.map((set) => ({ ...set, completed: true })),
}));

workoutSessionLocal.update(session.id, {
  status: "completed",
  endedAt: new Date().toISOString(),
  exercises: completedExercises,  // ← now persisted
});
```

The same `completedExercises` is passed into the `set()` call so the store state matches the persisted state.

## Verification

- TypeScript: no new errors
- After this fix, finishing a session via **Finish Session** correctly contributes to volume charts, ACWR, and completion stats

## Design note

This assumes that pressing **Finish Session** means the user considers all sets done (whether or not they individually tapped each one). If the intent was different (e.g. only count sets the user explicitly finished), the fix would need to be at the analytics-query level instead. Happy to adjust if the design intent differs.