### PR TITLE
fix(leaderboard): exclude incomplete (abandoned) workout sessions

### DIFF
--- a/src/features/leaderboard/actions/get-top-workout-users.action.ts
+++ b/src/features/leaderboard/actions/get-top-workout-users.action.ts
@@ -22,16 +22,16 @@ export const getTopWorkoutUsersAction = actionClient.schema(inputSchema).action(
   try {
     const { startDate, endDate } = getDateRangeForPeriod(period);
 
+    // Only count sessions the user actually finished. Abandoned sessions keep
+    // status "active" with endedAt null and would otherwise inflate counts.
+    const completedSessionFilter = {
+      endedAt: { not: null },
+      ...(startDate && { startedAt: { gte: startDate, lte: endDate } }),
+    };
+
     const whereClause = {
       WorkoutSession: {
-        some: startDate
-          ? {
-              startedAt: {
-                gte: startDate,
-                lte: endDate,
-              },
-            }
-          : {},
+        some: completedSessionFilter,
       },
     };
 
@@ -45,27 +45,13 @@ export const getTopWorkoutUsersAction = actionClient.schema(inputSchema).action(
         createdAt: true,
         _count: {
           select: {
-            WorkoutSession: startDate
-              ? {
-                  where: {
-                    startedAt: {
-                      gte: startDate,
-                      lte: endDate,
-                    },
-                  },
-                }
-              : true,
+            WorkoutSession: {
+              where: completedSessionFilter,
+            },
           },
         },
         WorkoutSession: {
-          where: startDate
-            ? {
-                startedAt: {
-                  gte: startDate,
-                  lte: endDate,
-                },
-              }
-            : undefined,
+          where: completedSessionFilter,
           select: {
             endedAt: true,
             startedAt: true,

--- a/src/features/leaderboard/actions/get-user-position.action.ts
+++ b/src/features/leaderboard/actions/get-user-position.action.ts
@@ -17,16 +17,18 @@ export const getUserPositionAction = actionClient.schema(inputSchema).action(asy
   try {
     const { startDate, endDate } = getDateRangeForPeriod(period);
 
+    // Only count sessions the user actually finished. Abandoned sessions keep
+    // status "active" with endedAt null and would otherwise inflate counts.
+    const completedSessionFilter = {
+      endedAt: { not: null },
+      ...(startDate && { startedAt: { gte: startDate, lte: endDate } }),
+    };
+
     // Get user's workout count
     const userWorkoutCount = await prisma.workoutSession.count({
       where: {
         userId,
-        ...(startDate && {
-          startedAt: {
-            gte: startDate,
-            lte: endDate,
-          },
-        }),
+        ...completedSessionFilter,
       },
     });
 
@@ -34,14 +36,7 @@ export const getUserPositionAction = actionClient.schema(inputSchema).action(asy
     const totalUsersWithWorkouts = await prisma.user.count({
       where: {
         WorkoutSession: {
-          some: startDate
-            ? {
-                startedAt: {
-                  gte: startDate,
-                  lte: endDate,
-                },
-              }
-            : {},
+          some: completedSessionFilter,
         },
       },
     });
@@ -50,30 +45,16 @@ export const getUserPositionAction = actionClient.schema(inputSchema).action(asy
     const allUsers = await prisma.user.findMany({
       where: {
         WorkoutSession: {
-          some: startDate
-            ? {
-                startedAt: {
-                  gte: startDate,
-                  lte: endDate,
-                },
-              }
-            : {},
+          some: completedSessionFilter,
         },
       },
       select: {
         id: true,
         _count: {
           select: {
-            WorkoutSession: startDate
-              ? {
-                  where: {
-                    startedAt: {
-                      gte: startDate,
-                      lte: endDate,
-                    },
-                  },
-                }
-              : true,
+            WorkoutSession: {
+              where: completedSessionFilter,
+            },
           },
         },
       },
@@ -83,6 +64,10 @@ export const getUserPositionAction = actionClient.schema(inputSchema).action(asy
         },
       },
     });
+
+    // Order by the number of *completed* sessions so abandoned ones cannot
+    // push a user up the ranking (the DB _count orderBy above is unfiltered).
+    allUsers.sort((a, b) => b._count.WorkoutSession - a._count.WorkoutSession);
 
     const position = allUsers.findIndex((user) => user.id === userId) + 1;
 


### PR DESCRIPTION
## What

The leaderboard counted workout sessions that a user started but never finished. When someone taps **Start workout** and then abandons it (closes the tab, navigates away), the session stays in the DB with `endedAt: null` but was still counted toward their ranking and total workout count.

## Why

All session-counting queries in the leaderboard actions filtered only on `startedAt` (for the date range) and never checked `endedAt`. An abandoned session has `status: "active"` and `endedAt: null`, yet passed every filter.

## Changes

- Introduce a shared `completedSessionFilter` that requires `endedAt: { not: null }` (plus the optional `startedAt` range) and apply it to **every** session-counting query in both actions:
  - `get-user-position.action.ts`: the user's own count, the \"users with workouts\" count, and the per-user `_count` used to compute position.
  - `get-top-workout-users.action.ts`: the `where` clause, the `_count`, and the \"last workout\" relation.
- In `get-user-position`, sort the candidate users by their **completed**-session count in JS, because Prisma's `orderBy: { WorkoutSession: { _count: \"desc\" } }` orders by the unfiltered relation count and would otherwise still let abandoned sessions influence ranking.

Fixes #211.