### PR TITLE
fix(workout-session): mark all sets completed when finishing a session

### DIFF
--- a/src/features/workout-session/model/workout-session.store.ts
+++ b/src/features/workout-session/model/workout-session.store.ts
@@ -135,16 +135,30 @@ export const useWorkoutSessionStore = create<WorkoutSessionState>((set, get) => 
     const { session } = get();
 
     if (session) {
-      workoutSessionLocal.update(session.id, { status: "completed", endedAt: new Date().toISOString() });
-      console.log({
-        session: { ...session, status: "completed", endedAt: new Date().toISOString() },
-        progress: {},
-        elapsedTime: 0,
-        isTimerRunning: false,
-        isWorkoutActive: false,
+      const endedAt = new Date().toISOString();
+
+      // Mark every set as completed so analytics (volume, ACWR, completion
+      // stats) account for the work done. Without this, sessions wrapped up via
+      // "Finish Session" instead of finishing each set keep sets at
+      // completed: false and become invisible to those calculations.
+      const completedExercises = session.exercises.map((exercise) => ({
+        ...exercise,
+        sets: exercise.sets.map((set) => ({ ...set, completed: true })),
+      }));
+
+      workoutSessionLocal.update(session.id, {
+        exercises: completedExercises,
+        status: "completed",
+        endedAt,
       });
+
       set({
-        session: { ...session, status: "completed", endedAt: new Date().toISOString() },
+        session: {
+          ...session,
+          exercises: completedExercises,
+          status: "completed",
+          endedAt,
+        },
         progress: {},
         elapsedTime: 0,
         isTimerRunning: false,


### PR DESCRIPTION
## What

When a user finishes a workout via **Finish Session** (the overall session-end button) without first clicking **Finish Set** on every set, the session is marked `status: \"completed\"` with `endedAt` set, but the individual sets keep `completed: false`.

## Why

`completeWorkout()` updated only session-level fields and never touched the per-set `completed` flag. Analytics that filter on `set.completed` therefore miss these sessions entirely:
- Volume calculations (`weightKg × reps` over `completed: true` sets) report zero
- ACWR fatigue curves show a false dip
- Exercise completion stats undercount

## Changes

In `completeWorkout()`, mark every set in the session as `completed: true` and persist the updated `exercises` alongside the session status/`endedAt`. Also removed a leftover debug `console.log` in the same function.

Fixes #212.