### PR TITLE
fix(leaderboard): make weekly period non-empty on Sundays

### DIFF
--- a/src/features/leaderboard/lib/utils.ts
+++ b/src/features/leaderboard/lib/utils.ts
@@ -15,8 +15,13 @@ export function getDateRangeForPeriod(period: LeaderboardPeriod): { startDate: D
 
   switch (period) {
     case "weekly": {
-      // Start of current week (Monday) in Paris timezone
-      const startOfWeek = now.startOf("week").add(1, "day"); // dayjs week starts on Sunday, add 1 for Monday
+      // Start of current week (Monday) in Paris timezone.
+      // dayjs' default week starts on Sunday, so deriving Monday via
+      // startOf("week").add(1, "day") inverts on a Sunday (start lands on the
+      // following Monday, which is *after* `now`) and yields an empty range.
+      // Compute Monday directly from the day-of-week instead.
+      const daysSinceMonday = (now.day() + 6) % 7; // Sun→6, Mon→0, …, Sat→5
+      const startOfWeek = now.subtract(daysSinceMonday, "day").startOf("day");
       return {
         startDate: startOfWeek.toDate(),
         endDate: now.toDate(),


### PR DESCRIPTION
## What

The **weekly** leaderboard (top users + your position) returns **no results every Sunday**. This is a bug I found while working on the leaderboard — it's not covered by #217 (which only filters by \`endedAt\`).

## Root cause

\`getDateRangeForPeriod(\"weekly\")\` in \`src/features/leaderboard/lib/utils.ts\` computes Monday as:

\`\`\`ts
const startOfWeek = now.startOf(\"week\").add(1, \"day\"); // dayjs week starts on Sunday, add 1 for Monday
\`\`\`

dayjs' default week starts on **Sunday**. On a Sunday, \`startOf(\"week\")\` is *today* (Sunday 00:00), so \`add(1, \"day\")\` lands on the **following Monday** — in the future. The range becomes \`startDate > endDate\`, and both leaderboard actions feed it into an inverted Prisma filter \`startedAt: { gte, lte }\` that matches zero sessions.

Quick table of the Monday offset (in days from today) for each weekday:

| Weekday | OLD offset | NEW offset |
|---|---|---|
| Sunday | **+1 (inverted!)** | −6 |
| Monday | 0 | 0 |
| Tuesday | −1 | −1 |
| … | … | … |
| Saturday | −5 | −5 |

Only Sunday is wrong, but it breaks the entire weekly view one day a week.

## Fix

Derive Monday from the day-of-week so it always points backwards:

\`\`\`ts
const daysSinceMonday = (now.day() + 6) % 7; // Sun→6, Mon→0, …, Sat→5
const startOfWeek = now.subtract(daysSinceMonday, \"day\").startOf(\"day\");
\`\`\`

\`monthly\` and \`all-time\` are unaffected.

Fixes #220.