### PR TITLE
fix(analytics): include minutes for time-based set volume stats

### DIFF
--- a/app/api/exercises/[exerciseId]/statistics/volume/route.ts
+++ b/app/api/exercises/[exerciseId]/statistics/volume/route.ts
@@ -145,9 +145,14 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
         } else if (repsIndex !== -1 && set.valuesInt && set.valuesInt[repsIndex]) {
           // Bodyweight exercise: count reps as volume
           volume = set.valuesInt[repsIndex];
-        } else if (timeIndex !== -1 && set.valuesSec && set.valuesSec[0]) {
-          // Time-based exercise: use seconds as volume
-          volume = set.valuesSec[0];
+        } else if (timeIndex !== -1 && (set.valuesInt || set.valuesSec)) {
+          // Time-based exercise: total duration in seconds. TIME stores minutes
+          // in valuesInt[timeIndex] and seconds in valuesSec[timeIndex]; the old
+          // valuesSec[0] guard both dropped the minutes and misread the index
+          // (and a 0-seconds value like a 3:00 plank was falsy and skipped).
+          const minutes = set.valuesInt?.[timeIndex] ?? 0;
+          const seconds = set.valuesSec?.[timeIndex] ?? 0;
+          volume = minutes * 60 + seconds;
         }
 
         if (volume > 0) {


### PR DESCRIPTION
## What

Per-exercise volume statistics (`/api/exercises/[id]/statistics/volume`) **dropped the minutes** for time-based sets and read from the wrong array index, so time-based exercises got wildly wrong volume numbers — a **3:00 plank showed 0 volume** while a 0:30 plank showed 30.

This is a bug I found while auditing the analytics code (not covered by any existing issue/PR).

## Root cause

A TIME column stores two values at the **same column index** (see `workout-session-set.tsx`):

- `valuesInt[columnIndex]` = minutes
- `valuesSec[columnIndex]` = seconds

The volume route read time-based sets like this:

```ts
} else if (timeIndex !== -1 && set.valuesSec && set.valuesSec[0]) {
  volume = set.valuesSec[0];
}
```

Two problems:

1. **Hardcoded `valuesSec[0]`** — wrong when TIME isn't the first column (`types: ["REPS","TIME"]` keeps seconds at `valuesSec[1]`).
2. **Minutes ignored entirely.** A 3:00 plank (`valuesInt:[3], valuesSec:[0]`) hit the falsy `set.valuesSec[0]` guard and was **skipped** (volume = 0), while a 0:30 plank got `volume = 30`.

## Fix

```ts
} else if (timeIndex !== -1 && (set.valuesInt || set.valuesSec)) {
  const minutes = set.valuesInt?.[timeIndex] ?? 0;
  const seconds = set.valuesSec?.[timeIndex] ?? 0;
  volume = minutes * 60 + seconds;
}
```

Reads from `timeIndex` (not a hardcoded 0), adds the minutes back in, and uses a non-falsy guard so a whole-minute entry isn't dropped. The downstream `volume > 0` check still correctly skips genuinely-empty entries (0 min + 0 sec).

Fixes #222.
