### PR TITLE
fix(analytics): read reps/weight by type index in session summary

### DIFF
--- a/app/api/workout-sessions/[sessionId]/summary/route.ts
+++ b/app/api/workout-sessions/[sessionId]/summary/route.ts
@@ -60,14 +60,19 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
         if (set.completed) {
           totalSets++;
 
-          // Calculate reps
-          if (set.types.includes("REPS") && set.valuesInt.length > 0) {
-            const reps = set.valuesInt[0];
+          // Read reps/weight by their type index. Columns are user-reorderable,
+          // so REPS isn't necessarily column 0 or WEIGHT column 1; reading
+          // valuesInt[0]/[1] scrambled the totals when a set was e.g.
+          // [WEIGHT, REPS].
+          const repsIndex = set.types.indexOf("REPS");
+          const weightIndex = set.types.indexOf("WEIGHT");
+
+          if (repsIndex !== -1 && set.valuesInt && set.valuesInt[repsIndex]) {
+            const reps = set.valuesInt[repsIndex];
             totalReps += reps;
 
-            // Calculate volume if weight is present
-            if (set.types.includes("WEIGHT") && set.valuesInt.length > 1) {
-              const weight = set.valuesInt[1];
+            if (weightIndex !== -1 && set.valuesInt && set.valuesInt[weightIndex]) {
+              const weight = set.valuesInt[weightIndex];
               totalVolume += weight * reps;
               totalWeightLifted += weight;
             }


### PR DESCRIPTION
## What

The workout-session summary endpoint (`/api/workout-sessions/[sessionId]/summary`) **misattributes reps and weight whenever the set columns aren't in the order `[REPS, WEIGHT]`**, silently scrambling `totalReps`, `totalVolume`, and `totalWeightLifted`.

This is a bug I found while auditing the analytics code — not covered by any existing issue/PR. I confirmed PR #198 still carries the same bug.

## Root cause

In `app/api/workout-sessions/[sessionId]/summary/route.ts`:

```ts
if (set.types.includes("REPS") && set.valuesInt.length > 0) {
  const reps = set.valuesInt[0];          // assumes REPS is column 0
  totalReps += reps;

  if (set.types.includes("WEIGHT") && set.valuesInt.length > 1) {
    const weight = set.valuesInt[1];      // assumes WEIGHT is column 1
    totalVolume += weight * reps;
    totalWeightLifted += weight;
  }
}
```

Set columns are **user-reorderable** (the type `<select>` lets a user set any column to any type), and values are stored at their column index. So:

- reps → `valuesInt[set.types.indexOf("REPS")]`
- weight → `valuesInt[set.types.indexOf("WEIGHT")]`

When a set is `[WEIGHT, REPS]`, the current code reads the **weight as reps** and the **reps as weight**. An `80 kg × 5` set stored as `[WEIGHT, REPS]` becomes `reps = 80, weight = 5` → `totalVolume += 400` instead of `400`... the numbers are wrong and a `valuesInt.length > 1` guard can even leak the wrong field when only one column exists.

The sibling stats routes (`statistics/volume`, `statistics/one-rep-max`, `weight-progression`) all read by `types.indexOf(...)`. This summary route was the only one with the hardcoded assumption.

## Fix

```ts
const repsIndex = set.types.indexOf("REPS");
const weightIndex = set.types.indexOf("WEIGHT");

if (repsIndex !== -1 && set.valuesInt && set.valuesInt[repsIndex]) {
  const reps = set.valuesInt[repsIndex];
  totalReps += reps;

  if (weightIndex !== -1 && set.valuesInt && set.valuesInt[weightIndex]) {
    const weight = set.valuesInt[weightIndex];
    totalVolume += weight * reps;
    totalWeightLifted += weight;
  }
}
```

Fixes #224.
