### PR TITLE
fix(analytics): normalize weight units (kg/lbs) in exercise stats

### DIFF
--- a/app/api/exercises/[exerciseId]/statistics/one-rep-max/route.ts
+++ b/app/api/exercises/[exerciseId]/statistics/one-rep-max/route.ts
@@ -6,6 +6,7 @@ import { prisma } from "@/shared/lib/prisma";
 import { PremiumService } from "@/shared/lib/premium/premium.service";
 import { STATISTICS_TIMEFRAMES, DEFAULT_TIMEFRAME, TIMEFRAME_DAYS, LOMBARDI_DIVISOR } from "@/shared/constants/statistics";
 import { getMobileCompatibleSession } from "@/shared/api/mobile-auth";
+import { convertWeight } from "@/shared/lib/weight-conversion";
 
 const timeframeSchema = z.enum([
   STATISTICS_TIMEFRAMES.FOUR_WEEKS,
@@ -127,7 +128,11 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
         const repsIndex = set.types.indexOf("REPS");
 
         if (weightIndex !== -1 && repsIndex !== -1 && set.valuesInt && set.valuesInt[weightIndex] && set.valuesInt[repsIndex]) {
-          const weight = set.valuesInt[weightIndex];
+          const rawWeightOrm = set.valuesInt[weightIndex];
+          // Normalize lbs -> kg so 1RM is unit-consistent regardless of
+          // which unit the set was logged in.
+          const unitOrm = set.units?.[weightIndex] === "lbs" ? "lbs" : "kg";
+          const weight = convertWeight(rawWeightOrm, unitOrm, "kg");
           const reps = set.valuesInt[repsIndex];
           const oneRepMax = calculateOneRepMax(weight, reps);
 

--- a/app/api/exercises/[exerciseId]/statistics/volume/route.ts
+++ b/app/api/exercises/[exerciseId]/statistics/volume/route.ts
@@ -6,6 +6,7 @@ import { prisma } from "@/shared/lib/prisma";
 import { PremiumService } from "@/shared/lib/premium/premium.service";
 import { STATISTICS_TIMEFRAMES, DEFAULT_TIMEFRAME, TIMEFRAME_DAYS } from "@/shared/constants/statistics";
 import { getMobileCompatibleSession } from "@/shared/api/mobile-auth";
+import { convertWeight } from "@/shared/lib/weight-conversion";
 
 const timeframeSchema = z.enum([
   STATISTICS_TIMEFRAMES.FOUR_WEEKS,
@@ -141,7 +142,12 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
         if (weightIndex !== -1 && repsIndex !== -1 && set.valuesInt && set.valuesInt[weightIndex] && set.valuesInt[repsIndex]) {
           // Weight-based exercise: reps × weight
-          volume = set.valuesInt[repsIndex] * set.valuesInt[weightIndex];
+          // Normalize weight to kg so mixed kg/lbs sessions aggregate
+          // on a single unit (users can switch units per set).
+          const rawWeightVol = set.valuesInt[weightIndex];
+          const unitVol = set.units?.[weightIndex] === "lbs" ? "lbs" : "kg";
+          const weightKg = convertWeight(rawWeightVol, unitVol, "kg");
+          volume = set.valuesInt[repsIndex] * weightKg;
         } else if (repsIndex !== -1 && set.valuesInt && set.valuesInt[repsIndex]) {
           // Bodyweight exercise: count reps as volume
           volume = set.valuesInt[repsIndex];

--- a/app/api/exercises/[exerciseId]/statistics/weight-progression/route.ts
+++ b/app/api/exercises/[exerciseId]/statistics/weight-progression/route.ts
@@ -6,6 +6,7 @@ import { prisma } from "@/shared/lib/prisma";
 import { PremiumService } from "@/shared/lib/premium/premium.service";
 import { STATISTICS_TIMEFRAMES, DEFAULT_TIMEFRAME, TIMEFRAME_DAYS } from "@/shared/constants/statistics";
 import { getMobileCompatibleSession } from "@/shared/api/mobile-auth";
+import { convertWeight } from "@/shared/lib/weight-conversion";
 
 const timeframeSchema = z.enum([
   STATISTICS_TIMEFRAMES.FOUR_WEEKS,
@@ -121,7 +122,11 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
         // Find weight value from arrays
         const weightIndex = set.types.indexOf("WEIGHT");
         if (weightIndex !== -1 && set.valuesInt && set.valuesInt[weightIndex]) {
-          const weight = set.valuesInt[weightIndex];
+          const rawWeight = set.valuesInt[weightIndex];
+          // Normalize lbs -> kg so the trend line is unit-consistent
+          // (users can switch units or mix them across sessions).
+          const unit = set.units?.[weightIndex] === "lbs" ? "lbs" : "kg";
+          const weight = convertWeight(rawWeight, unit, "kg");
           if (weight > maxWeight) {
             maxWeight = weight;
           }


### PR DESCRIPTION
## What

All three exercise statistics routes plot/aggregate **raw weight values without normalizing units**, so a user who switches between kg and lb (or mixes them across sessions) gets a misleading trend line. A 50 lb set and a 50 kg set both read as "50", and a 110 lb set sits far below a 50 kg set on the same axis.

Bug found while auditing the analytics code — not covered by any existing issue/PR.

## Root cause

Each route reads the weight straight out of the value array and never consults `units[weightIndex]`:

- `weight-progression/route.ts`: `const weight = set.valuesInt[weightIndex]`
- `volume/route.ts`: `volume = reps × set.valuesInt[weightIndex]`
- `one-rep-max/route.ts`: `const weight = set.valuesInt[weightIndex]`

The set stores its unit (`"kg"` / `"lbs"`) at `units[weightIndex]`, but it's ignored. The app already ships `convertWeight()` / `WEIGHT_CONVERSION` in `src/shared/lib/weight-conversion.ts`.

## Fix

Normalize each weight to kg before aggregating, in all three routes:

```ts
import { convertWeight } from "@/shared/lib/weight-conversion";

const rawWeight = set.valuesInt[weightIndex];
const unit = set.units?.[weightIndex] === "lbs" ? "lbs" : "kg";
const weight = convertWeight(rawWeight, unit, "kg");
```

Now a 50 lb and a 50 kg set are no longer treated as equal, and mid-history unit switches don't make the line jump. Aggregates (per-session max weight, total volume, estimated 1RM) become unit-consistent.

Fixes #226.
