### PR TITLE
fix(programs): set suggested set programExerciseId to the real exercise id

### DIFF
--- a/src/features/programs/actions/get-session-by-slug.action.ts
+++ b/src/features/programs/actions/get-session-by-slug.action.ts
@@ -165,7 +165,7 @@ export async function getSessionBySlug(
           suggestedSets: ex.suggestedSets.map((set) => ({
             id: set.id,
             programSessionExerciseId: set.programSessionExerciseId,
-            programExerciseId: set.programSessionExerciseId,
+            programExerciseId: ex.exerciseId,
             setIndex: set.setIndex,
             types: set.types,
             valuesInt: set.valuesInt,


### PR DESCRIPTION
## What

In `get-session-by-slug.action.ts`, each suggested set's `programExerciseId` is filled with the **session-exercise** id instead of a program-exercise reference — a copy/paste assigning the same value to two fields.

```ts
suggestedSets: ex.suggestedSets.map((set) => ({
  id: set.id,
  programSessionExerciseId: set.programSessionExerciseId,
  programExerciseId: set.programSessionExerciseId,   // ← same as above
```

`set.programSessionExerciseId` is the parent `ProgramSessionExercise.id` (`ex.id`). The `ProgramSuggestedSet` model has no `programExerciseId` column, so the field is synthesized — and it's synthesized to the wrong value: it always mirrors `programSessionExerciseId`. The real program-exercise identity in this scope is `ex.exerciseId` (the underlying `Exercise.id`).

## Impact

Latent: the current `ProgramSessionClient` doesn't read `programExerciseId` (it consumes `types`/`valuesInt`/`valuesSec`/`units`), so today's UI is unaffected. But `SuggestedSet` declares the field, so any future consumer or test gets a silently wrong value.

## Fix

Carry the parent's real exercise id into the mapped set:

```ts
programExerciseId: ex.exerciseId,
```

Fixes #228.
