### PR TITLE
fix(programs): scope session-progress/start session to the enrolled program

### DIFF
--- a/app/api/programs/session-progress/start/route.ts
+++ b/app/api/programs/session-progress/start/route.ts
@@ -59,7 +59,11 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    if (!programSession) {
+    if (!programSession || programSession.week.programId !== enrollment.program.id) {
+      // Reject a sessionId that doesn't belong to the program the enrollment is
+      // for; otherwise we'd create a UserSessionProgress pointing at a session
+      // from another program and overwrite the user's currentWeek/currentSession
+      // with that program's values.
       return NextResponse.json({ error: "Session not found" }, { status: 404 });
     }
 


### PR DESCRIPTION
## What

`POST /api/programs/session-progress/start` created a `UserSessionProgress` for **any session id** the client passed, without checking that the session belongs to the program the enrollment is for. The user's enrollment pointer (`currentWeek` / `currentSession`) was then overwritten with numbers from that unrelated session.

Bug found while auditing the programs API — not covered by any existing issue/PR.

## Root cause

In `app/api/programs/session-progress/start/route.ts`:

```ts
const enrollment = await prisma.userProgramEnrollment.findFirst({
  where: { id: enrollmentId, userId },
  include: { program: true },
});
...
const programSession = await prisma.programSession.findUnique({
  where: { id: sessionId },     // no programId constraint
});
...
await prisma.userSessionProgress.create({ data: { enrollmentId, sessionId } });
await prisma.userProgramEnrollment.update({
  where: { id: enrollmentId },
  data: {
    currentWeek: programSession.week.weekNumber,    // from the OTHER program
    currentSession: programSession.sessionNumber,   // from the OTHER program
  },
});
```

The enrollment captures `programId` (program A), but `programSession.week.programId` (program B) is never compared. `UserSessionProgress` only relates to `ProgramSession`, not to the enrollment's program, so the schema doesn't enforce a match either.

A request `{ enrollmentId: <enrollment in Program A>, sessionId: <Program-B session> }` would (1) create a progress row linking a Program-A enrollment to a Program-B session, (2) overwrite the enrollment's `currentWeek`/`currentSession` with Program-B's values, (3) break the user's real position (the `complete` route then inherits the wrong row).

## Fix

Reject any session whose week's `programId` doesn't match the enrollment's program:

```ts
if (!programSession || programSession.week.programId !== enrollment.program.id) {
  return NextResponse.json({ error: "Session not found" }, { status: 404 });
}
```

`enrollment.program` is already loaded and `programSession.week` is already included, so no extra query is needed.

Fixes #230.
