### PR TITLE
fix(programs): clamp completed-session nextWeek to program max week

### DIFF
--- a/app/api/programs/session-progress/[progressId]/complete/route.ts
+++ b/app/api/programs/session-progress/[progressId]/complete/route.ts
@@ -63,9 +63,12 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
 
     const currentWeekSessions =
       sessionProgress.enrollment.program.weeks.find((w) => w.weekNumber === currentWeek)?.sessions.length || 0;
+    const maxWeek = Math.max(...sessionProgress.enrollment.program.weeks.map((w) => w.weekNumber));
 
     if (nextSession > currentWeekSessions) {
-      nextWeek = currentWeek + 1;
+      // Clamp to the program's last week so out-of-order completion can't strand
+      // the user on a "ghost week" that has no sessions.
+      nextWeek = Math.min(currentWeek + 1, maxWeek);
       nextSession = 1;
     }
 

--- a/src/features/programs/actions/complete-program-session.action.ts
+++ b/src/features/programs/actions/complete-program-session.action.ts
@@ -80,9 +80,12 @@ export async function completeProgramSession(sessionProgressId: string, workoutS
 
   // Check if we need to move to next week
   const currentWeekSessions = enrollment.program.weeks.find((w) => w.weekNumber === currentWeek)?.sessions.length || 0;
+  const maxWeek = Math.max(...enrollment.program.weeks.map((w) => w.weekNumber));
 
   if (nextSession > currentWeekSessions) {
-    nextWeek = currentWeek + 1;
+    // Clamp to the program's last week so out-of-order completion can't strand
+    // the user on a "ghost week" that has no sessions.
+    nextWeek = Math.min(currentWeek + 1, maxWeek);
     nextSession = 1;
   }
 


### PR DESCRIPTION
## What

Completing a program session **out of order** could write a `currentWeek` that doesn't exist in the program, stranding the user on an empty "ghost week".

Bug found while auditing the programs API — not covered by any existing issue/PR.

## Reproduction

Program: 2 weeks (W1: 2 sessions, W2: 2 sessions). Complete **W2/S2 while W2/S1 is still incomplete** (out-of-order completion, which the app otherwise supports).

Both `complete-program-session.action.ts` and `app/api/programs/session-progress/[progressId]/complete/route.ts` share this wrap (duplicated verbatim):

```ts
if (nextSession > currentWeekSessions) {
  nextWeek = currentWeek + 1;   // never clamped
  nextSession = 1;
}
```

For `currentWeek=2, currentSession=2`, completed count `1 < total 4` → `isCompleted=false`:

```
{ isCompleted: false, nextWeek: 3, nextSession: 1 }   // program only has weeks 1–2!
```

The enrollment is saved `currentWeek=3`, and on the program page `setSelectedWeek(progress.stats.currentWeek)` selects week 3 — which has no sessions. The user is stuck on an empty week (resume pointer permanently wrong until enough sessions flip `isCompleted`).

## Fix

Clamp the week increment to the program's last week:

```ts
const maxWeek = Math.max(...enrollment.program.weeks.map((w) => w.weekNumber));
if (nextSession > currentWeekSessions) {
  nextWeek = Math.min(currentWeek + 1, maxWeek);
  nextSession = 1;
}
```

When the program is genuinely done, `isCompleted` already guards the write. Verified against the repro: out-of-order completion now lands on `week 2 / session 1` (a real week) instead of `week 3`. Fixed in both copies.

Fixes #232.
