### PR TITLE
fix(locales): enable English fallback for missing translation keys

### DIFF
--- a/locales/client.ts
+++ b/locales/client.ts
@@ -37,8 +37,9 @@ export const { useI18n, useScopedI18n, I18nProviderClient, useChangeLocale, defi
     // basePath: '/base',
     // Uncomment to use custom segment name
     // segmentName: 'locale',
-    // Uncomment to set fallback locale
-    // fallbackLocale: en,
+    // Fall back to English for any key missing from a locale, so untranslated
+    // keys show English text instead of the raw "section.key" path.
+    fallbackLocale: en,
   },
 );
 


### PR DESCRIPTION
## What

Missing translation keys render as **raw key paths** (e.g. `heatmap.no_workout`) instead of falling back to English, because the `fallbackLocale` option is commented out in `locales/client.ts`.

## Root cause

```ts
// Uncomment to set fallback locale
// fallbackLocale: en,
```

`next-international`'s `createI18nClient` supports `fallbackLocale`, which makes missing keys fall back to the specified locale. It's disabled, so every untranslated key shows its raw dotted path.

138 keys are currently missing across es/pt/ru/fr (zh-CN partially covered by #200). Examples showing as raw paths today:
- `heatmap.no_workout` / `heatmap.one_workout_unit` / `heatmap.multiple_workouts_unit`
- `health_risks.overweight.*` / `health_risks.underweight.*` (~25 each, BMI results page)
- `commons.refresh`, `workout_builder.muscles.lats`

## Fix

One line — uncomment and enable:

```ts
fallbackLocale: en,
```

This immediately improves every locale (and future ones): missing keys show English instead of raw paths. Complementary to translation-completion PRs like #200 — the fallback is a safety net for any key not yet translated.

Fixes #234.
