### PR TITLE
fix(workout-session): require auth + ownership to delete a workout session

### DIFF
--- a/src/features/workout-session/actions/delete-workout-session.action.ts
+++ b/src/features/workout-session/actions/delete-workout-session.action.ts
@@ -3,13 +3,13 @@
 import { z } from "zod";
 
 import { prisma } from "@/shared/lib/prisma";
-import { actionClient } from "@/shared/api/safe-actions";
+import { authenticatedActionClient } from "@/shared/api/safe-actions";
 
 const deleteWorkoutSessionSchema = z.object({
   id: z.string(),
 });
 
-export const deleteWorkoutSessionAction = actionClient.schema(deleteWorkoutSessionSchema).action(async ({ parsedInput }) => {
+export const deleteWorkoutSessionAction = authenticatedActionClient.schema(deleteWorkoutSessionSchema).action(async ({ parsedInput, ctx }) => {
   try {
     const { id } = parsedInput;
 
@@ -18,7 +18,9 @@ export const deleteWorkoutSessionAction = actionClient.schema(deleteWorkoutSessi
       select: { userId: true },
     });
 
-    if (!session) {
+    // Return the same error for missing and non-owned sessions so the endpoint
+    // cannot be used to disclose which session ids exist.
+    if (!session || session.userId !== ctx.user.id) {
       console.error("❌ Session not found:", id);
       return { serverError: "Session not found" };
     }


### PR DESCRIPTION
## What

`deleteWorkoutSessionAction` let any logged-in user delete **any other user's** workout session. It was built on the unauthenticated `actionClient`, fetched the session's `userId` but never compared it to the caller, and deleted by `id` alone.

## Root cause

```ts
export const deleteWorkoutSessionAction = actionClient.schema(...).action(async ({ parsedInput }) => {
  const { id } = parsedInput;
  const session = await prisma.workoutSession.findUnique({
    where: { id },
    select: { userId: true },     // fetched, then discarded
  });
  if (!session) { ... }
  await prisma.workoutSession.delete({ where: { id } });  // deletes unconditionally
});
```

`actionClient` performs no auth (vs `authenticatedActionClient`, which injects `ctx.user` via `serverAuth()`). The action had no idea who the caller was, so the selected `userId` could never be checked.

## Fix

Switch to `authenticatedActionClient` and require ownership:

```ts
export const deleteWorkoutSessionAction = authenticatedActionClient
  .schema(deleteWorkoutSessionSchema)
  .action(async ({ parsedInput, ctx }) => {
    const { id } = parsedInput;
    const session = await prisma.workoutSession.findUnique({ where: { id }, select: { userId: true } });
    if (!session || session.userId !== ctx.user.id) {
      return { serverError: "Session not found" };
    }
    await prisma.workoutSession.delete({ where: { id } });
    return { success: true };
  });
```

The same "not found" is returned for missing and non-owned rows to avoid disclosing which session ids exist.

Fixes #238.
