### PR TITLE
fix(workout-session): override client userId in sync route from auth session

### DIFF
--- a/app/api/workout-sessions/sync/route.ts
+++ b/app/api/workout-sessions/sync/route.ts
@@ -19,7 +19,12 @@ export async function POST(request: NextRequest) {
     }
 
     // Use the existing server action
-    const result = await syncWorkoutSessionAction({ session: body.session });
+    // Override the client-supplied userId with the authenticated user so a
+    // logged-in caller cannot sync (create/overwrite) a session under another
+    // user's account.
+    const result = await syncWorkoutSessionAction({
+      session: { ...body.session, userId: session.user.id },
+    });
 
     if (result?.serverError) {
       return NextResponse.json({ error: result.serverError }, { status: 500 });


### PR DESCRIPTION
## What

`POST /api/workout-sessions/sync` let an authenticated user **write workout data as another user**. The route authenticated the caller but forwarded the client-supplied `body.session` (including `body.session.userId`) unchanged, so a logged-in attacker could sync a session under any `userId`.

## Root cause

```ts
const session = await getMobileCompatibleSession(request);
if (!session?.user) { return 401; }
const body = await request.json();
...
const result = await syncWorkoutSessionAction({ session: body.session });  // body.session.userId is attacker-controlled
```

The downstream `syncWorkoutSessionAction` only checks the supplied `userId` *exists* (`userExists`), not that it matches the caller — so the attacker's `userId` flows into the `upsert` and the row is created/updated under the victim's account. Same class as #238 (delete), on the write path.

## Fix

Override the client-supplied userId with the authenticated user's id before calling the action:

```ts
const result = await syncWorkoutSessionAction({
  session: { ...body.session, userId: session.user.id },
});
```

Fixes #240.
