### PR TITLE
fix(seo): map zh-CN locale to zh for OG image filenames

### DIFF
--- a/app/[locale]/(app)/page.tsx
+++ b/app/[locale]/(app)/page.tsx
@@ -8,6 +8,8 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   const { locale } = await params;
 
   const isEnglish = locale === "en";
+  // OG images use "zh" for zh-CN (the file is default-og-image_zh.jpg)
+  const ogImageLocale = locale === "zh-CN" ? "zh" : locale;
   const title = isEnglish ? "Build Your Perfect Workout" : "Créez Votre Entraînement Parfait";
   const description = isEnglish
     ? "Create free workout routines with our comprehensive exercise database. Track your progress and achieve your fitness goals. 🏋️"
@@ -31,7 +33,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
       description,
       images: [
         {
-          url: `${getServerUrl()}/images/default-og-image_${locale}.jpg`,
+          url: `${getServerUrl()}/images/default-og-image_${ogImageLocale}.jpg`,
           width: SiteConfig.seo.ogImage.width,
           height: SiteConfig.seo.ogImage.height,
           alt: title,
@@ -41,7 +43,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
     twitter: {
       title: `${title} | ${SiteConfig.title}`,
       description,
-      images: [`${getServerUrl()}/images/default-og-image_${locale}.jpg`],
+      images: [`${getServerUrl()}/images/default-og-image_${ogImageLocale}.jpg`],
     },
   };
 }

--- a/src/shared/lib/structured-data.ts
+++ b/src/shared/lib/structured-data.ts
@@ -216,7 +216,7 @@ export function generateStructuredData({
                   : locale === "zh-CN"
                     ? "最新更新包括改进的运动数据库和更好的用户体验"
                     : "La dernière mise à jour inclut une base de données d'exercices améliorée et une meilleure expérience utilisateur",
-        screenshot: image || `${baseUrl}/images/default-og-image_${locale}.jpg`,
+        screenshot: image || `${baseUrl}/images/default-og-image_${locale === "zh-CN" ? "zh" : locale}.jpg`,
         aggregateRating: {
           "@type": "AggregateRating",
           ratingValue: "4.8",
@@ -247,7 +247,7 @@ export function generateStructuredData({
         },
         datePublished: datePublished || new Date().toISOString(),
         dateModified: dateModified || new Date().toISOString(),
-        image: image || `${baseUrl}/images/default-og-image_${locale}.jpg`,
+        image: image || `${baseUrl}/images/default-og-image_${locale === "zh-CN" ? "zh" : locale}.jpg`,
         mainEntityOfPage: {
           "@type": "WebPage",
           "@id": url,


### PR DESCRIPTION
## What

The home page's OpenGraph / Twitter card image was **broken for the zh-CN locale**, because `page.tsx` and two spots in `structured-data.ts` interpolated the raw locale into the filename (`default-og-image_zh-CN.jpg`) while the actual file is `default-og-image_zh.jpg`.

## Root cause

`app/[locale]/(app)/page.tsx` (lines 34, 44):
```ts
url: `${getServerUrl()}/images/default-og-image_${locale}.jpg`,
```

For `locale === "zh-CN"` this produces `default-og-image_zh-CN.jpg` — **doesn't exist**. The codebase already handles this mismatch in 5 other places (`locale === "zh-CN" ? "zh" : locale`):
- `app/[locale]/layout.tsx:157`
- `src/components/seo/SEOHead.tsx:49,183`
- `src/shared/lib/structured-data.ts:269`

…but misses it in:
- `app/[locale]/(app)/page.tsx:34,44` (home page metadata)
- `src/shared/lib/structured-data.ts:219,250` (structured data)

## Fix

Apply the same `zh-CN` → `zh` mapping in all 4 missed spots.

Fixes #243.
