### PR TITLE
fix(peptide-calculator): stop iOS zooming the viewport on the free-entry field

### DIFF
--- a/app/[locale]/(app)/tools/peptide-calculator/ui/components/NumberField.tsx
+++ b/app/[locale]/(app)/tools/peptide-calculator/ui/components/NumberField.tsx
@@ -22,6 +22,11 @@ interface NumberFieldProps {
  * It keeps its own text draft rather than rendering `String(value)`: a controlled number
  * input would erase the half-typed `0.` the moment it fails to parse. The draft is only
  * re-synced when the value changes from the outside — a preset chip, a unit switch.
+ *
+ * `text-base` is load-bearing, not a style choice. Safari on iOS zooms the viewport when it
+ * focuses an input whose computed font-size is under 16px, and the zoom does not undo itself
+ * — the whole calculator ends up scaled and cropped. Anything below `text-base` here brings
+ * that back.
  */
 export function NumberField({ label, value, onChange, unit, step, conversion, autoFocus }: NumberFieldProps) {
   const [draft, setDraft] = useState(() => String(value));
@@ -35,7 +40,7 @@ export function NumberField({ label, value, onChange, unit, step, conversion, au
       <input
         aria-label={label}
         autoFocus={autoFocus}
-        className="min-w-0 flex-1 rounded-lg border border-slate-400 bg-base-100 px-3 py-[11px] text-sm font-semibold text-base-content shadow-3xl outline-none transition focus:border-primary focus:ring-4 focus:ring-primary/20 dark:border-slate-600"
+        className="min-w-0 flex-1 rounded-lg border border-slate-400 bg-base-100 px-3 py-[11px] text-base font-semibold text-base-content shadow-3xl outline-none transition focus:border-primary focus:ring-4 focus:ring-primary/20 dark:border-slate-600"
         min={0}
         onChange={(event) => {
           setDraft(event.target.value);


### PR DESCRIPTION
Follow-up to #246, which is already merged. The only content difference against `main` is this one file.

## The bug

Safari on iOS zooms the page when it focuses an input whose computed `font-size` is under 16px, and it does not zoom back out. Tapping "Other…" on the calculator left the whole widget scaled and cropped for the rest of the session.

## The cause

The field was `text-sm`. The project does not override Tailwind's `sm` step and the root size is 16px, so that computed to 14px — just under the threshold. `text-base` puts it at 16px exactly.

## Verified

In an emulated 390px iOS viewport: computed `font-size` 16px, the field still fits (9 → 355 of 390), page horizontal overflow stays at 0. `pnpm lint` exits 0, 28 tests pass.

## Same bug elsewhere, not fixed here

`src/components/ui/input.tsx` is `text-sm/[10px]` (14px), and its `Search` variant is `text-xs` (12px). Every form using the shared input zooms the same way on iPhone. Left alone deliberately — shared chrome, worth its own change.