### PR TITLE
fix(workout-builder): require all inferred exercise equipment

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "db:seed": "pnpm run import:exercises-full ./data/sample-exercises.csv",
     "db:seed-plans": "tsx scripts/seed-subscription-plans-simple.ts",
     "db:seed-workout-advanced": "tsx scripts/seed-workout-data-advanced.ts",
+    "backfill:equipment": "tsx scripts/backfill-equipment-tags.ts",
     "lint:fix": "next lint --fix",
     "db:seed-leaderboard": "tsx scripts/seed-leaderboard-data.ts",
     "migrate:prod": "env-cmd -f .env.production prisma migrate deploy",

--- a/scripts/backfill-equipment-tags.ts
+++ b/scripts/backfill-equipment-tags.ts
@@ -1,0 +1,107 @@
+import { ExerciseAttributeNameEnum, ExerciseAttributeValueEnum, PrismaClient } from "@prisma/client";
+
+import {
+  inferAdditionalEquipmentRequirements,
+  type InferredEquipmentRequirement,
+} from "../src/shared/lib/exercise-equipment";
+
+const prisma = new PrismaClient();
+
+const REQUIREMENTS: readonly InferredEquipmentRequirement[] = [
+  ExerciseAttributeValueEnum.BENCH,
+  ExerciseAttributeValueEnum.STEP,
+  ExerciseAttributeValueEnum.BOX,
+  ExerciseAttributeValueEnum.DESK,
+  ExerciseAttributeValueEnum.BANDS,
+  ExerciseAttributeValueEnum.TRX,
+  ExerciseAttributeValueEnum.PULLUP_BAR,
+];
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  const equipmentAttributeName = await prisma.exerciseAttributeName.findUnique({
+    where: { name: ExerciseAttributeNameEnum.EQUIPMENT },
+  });
+
+  if (!equipmentAttributeName) {
+    throw new Error("EQUIPMENT attribute name is missing");
+  }
+
+  const attributeValues = new Map<InferredEquipmentRequirement, string>();
+  for (const value of REQUIREMENTS) {
+    const attributeValue = await prisma.exerciseAttributeValue.upsert({
+      where: {
+        attributeNameId_value: {
+          attributeNameId: equipmentAttributeName.id,
+          value,
+        },
+      },
+      update: {},
+      create: {
+        attributeNameId: equipmentAttributeName.id,
+        value,
+      },
+    });
+    attributeValues.set(value, attributeValue.id);
+  }
+
+  const exercises = await prisma.exercise.findMany({
+    include: {
+      attributes: {
+        where: { attributeNameId: equipmentAttributeName.id },
+        include: { attributeValue: true },
+      },
+    },
+    orderBy: { nameEn: "asc" },
+  });
+
+  let changedCount = 0;
+  const addedCounts = new Map<InferredEquipmentRequirement, number>();
+  const samples: string[] = [];
+
+  for (const exercise of exercises) {
+    const required = inferAdditionalEquipmentRequirements(exercise);
+    const existing = new Set(exercise.attributes.map((attribute) => attribute.attributeValue.value));
+    const missing = required.filter((value) => !existing.has(value));
+
+    if (missing.length === 0) continue;
+
+    if (apply) {
+      await prisma.$transaction(
+        missing.map((value) =>
+          prisma.exerciseAttribute.create({
+            data: {
+              exerciseId: exercise.id,
+              attributeNameId: equipmentAttributeName.id,
+              attributeValueId: attributeValues.get(value)!,
+            },
+          }),
+        ),
+      );
+    }
+
+    changedCount += 1;
+    for (const value of missing) {
+      addedCounts.set(value, (addedCounts.get(value) ?? 0) + 1);
+    }
+    if (samples.length < 30) {
+      samples.push(`${exercise.nameEn ?? exercise.name}: +${missing.join(", ")}`);
+    }
+  }
+
+  console.log(apply ? "Applied equipment tag changes" : "Dry run; no database changes were written");
+  console.log(`Exercises with missing tags: ${changedCount}`);
+  const summary = REQUIREMENTS.map((value) => `${value}: ${addedCounts.get(value) ?? 0}`);
+  console.log(`Tags added: ${summary.join(", ")}`);
+  if (samples.length > 0) {
+    console.log("Samples:");
+    for (const sample of samples) console.log(`  ${sample}`);
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/import-exercises-with-attributes.ts
+++ b/scripts/import-exercises-with-attributes.ts
@@ -4,6 +4,8 @@ import fs from "fs";
 import csv from "csv-parser";
 import { ExerciseAttributeNameEnum, ExerciseAttributeValueEnum, PrismaClient } from "@prisma/client";
 
+import { inferAdditionalEquipmentRequirements } from "../src/shared/lib/exercise-equipment";
+
 const prisma = new PrismaClient();
 
 interface ExerciseAttributeCSVRow {
@@ -20,6 +22,29 @@ interface ExerciseAttributeCSVRow {
   slug_en: string;
   attribute_name: string;
   attribute_value: string;
+}
+
+interface GroupedExercise {
+  originalId: string;
+  name: string;
+  nameEn: string | null;
+  description: string | null;
+  descriptionEn: string | null;
+  fullVideoUrl: string | null;
+  fullVideoImageUrl: string | null;
+  introduction: string | null;
+  introductionEn: string | null;
+  slug: string;
+  slugEn: string;
+  attributes: Array<{
+    attributeName: string;
+    attributeValue: string;
+  }>;
+}
+
+interface ResolvedExerciseAttribute {
+  attributeName: ExerciseAttributeNameEnum;
+  attributeValue: ExerciseAttributeValueEnum;
 }
 
 function cleanValue(value: string): string | null {
@@ -60,6 +85,32 @@ function groupExercisesByOriginalId(rows: ExerciseAttributeCSVRow[]) {
   }
 
   return Array.from(exercisesMap.values());
+}
+
+function resolveExerciseAttributes(exercise: GroupedExercise): ResolvedExerciseAttribute[] {
+  const equipmentValues = exercise.attributes
+    .filter((attribute) => attribute.attributeName === ExerciseAttributeNameEnum.EQUIPMENT)
+    .map((attribute) => normalizeAttributeValue(attribute.attributeValue));
+  const inferredEquipment = inferAdditionalEquipmentRequirements(exercise);
+  const allEquipment = [...equipmentValues, ...inferredEquipment].filter(
+    (value, index, values) => values.indexOf(value) === index,
+  );
+  const equipmentToAdd = inferredEquipment.length > 0
+    ? allEquipment.filter((value) => value !== ExerciseAttributeValueEnum.BODY_ONLY)
+    : allEquipment;
+
+  return [
+    ...exercise.attributes
+      .filter((attribute) => attribute.attributeName !== ExerciseAttributeNameEnum.EQUIPMENT)
+      .map((attribute) => ({
+        attributeName: attribute.attributeName as ExerciseAttributeNameEnum,
+        attributeValue: normalizeAttributeValue(attribute.attributeValue),
+      })),
+    ...equipmentToAdd.map((value) => ({
+      attributeName: ExerciseAttributeNameEnum.EQUIPMENT,
+      attributeValue: value,
+    })),
+  ];
 }
 
 async function ensureAttributeNameExists(name: ExerciseAttributeNameEnum) {
@@ -162,7 +213,7 @@ async function importExercisesFromCSV(filePath: string) {
               });
 
               // Create new attributes
-              for (const attr of exercise.attributes) {
+              for (const attr of resolveExerciseAttributes(exercise)) {
                 try {
                   const attributeName = await ensureAttributeNameExists(attr.attributeName);
                   const attributeValue = await ensureAttributeValueExists(attributeName.id, normalizeAttributeValue(attr.attributeValue));

--- a/src/features/workout-builder/actions/get-exercises-by-muscle.action.ts
+++ b/src/features/workout-builder/actions/get-exercises-by-muscle.action.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { ExerciseAttributeNameEnum, ExerciseAttributeValueEnum } from "@prisma/client";
 
 import { prisma } from "@/shared/lib/prisma";
+import { buildEquipmentRequirementsFilter } from "@/shared/lib/exercise-equipment";
 import { actionClient } from "@/shared/api/safe-actions";
 
 
@@ -62,16 +63,7 @@ export const getExercisesByMuscleAction = actionClient
                   },
                 },
                 {
-                  attributes: {
-                    some: {
-                      attributeNameId: equipmentAttributeName.id,
-                      attributeValue: {
-                        value: {
-                          in: equipment,
-                        },
-                      },
-                    },
-                  },
+                  AND: buildEquipmentRequirementsFilter(equipment, equipmentAttributeName.id),
                 },
                 // Exclude stretching exercises
                 {

--- a/src/features/workout-builder/actions/get-exercises.action.ts
+++ b/src/features/workout-builder/actions/get-exercises.action.ts
@@ -5,8 +5,8 @@ import { ExerciseAttributeNameEnum } from "@prisma/client";
 import { getExercisesSchema } from "../schema/get-exercises.schema";
 
 import { prisma } from "@/shared/lib/prisma";
+import { buildEquipmentRequirementsFilter } from "@/shared/lib/exercise-equipment";
 import { actionClient } from "@/shared/api/safe-actions";
-
 
 // Utility function to shuffle an array (Fisher-Yates shuffle)
 function shuffleArray<T>(array: T[]): T[] {
@@ -60,16 +60,7 @@ export const getExercisesAction = actionClient.schema(getExercisesSchema).action
                 },
               },
               {
-                attributes: {
-                  some: {
-                    attributeNameId: equipmentAttributeName.id,
-                    attributeValue: {
-                      value: {
-                        in: equipment,
-                      },
-                    },
-                  },
-                },
+                AND: buildEquipmentRequirementsFilter(equipment, equipmentAttributeName.id),
               },
               // Exclude stretching exercises
               {
@@ -114,16 +105,7 @@ export const getExercisesAction = actionClient.schema(getExercisesSchema).action
                   },
                 },
                 {
-                  attributes: {
-                    some: {
-                      attributeNameId: equipmentAttributeName.id,
-                      attributeValue: {
-                        value: {
-                          in: equipment,
-                        },
-                      },
-                    },
-                  },
+                AND: buildEquipmentRequirementsFilter(equipment, equipmentAttributeName.id),
                 },
                 // Exclude exercises already found as primary
                 {

--- a/src/features/workout-builder/actions/shuffle-exercise.action.ts
+++ b/src/features/workout-builder/actions/shuffle-exercise.action.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { ExerciseAttributeNameEnum, ExerciseAttributeValueEnum } from "@prisma/client";
 
 import { prisma } from "@/shared/lib/prisma";
+import { buildEquipmentRequirementsFilter } from "@/shared/lib/exercise-equipment";
 import { actionClient } from "@/shared/api/safe-actions";
 
 const shuffleExerciseSchema = z.object({
@@ -51,16 +52,7 @@ export const shuffleExerciseAction = actionClient.schema(shuffleExerciseSchema).
             },
           },
           {
-            attributes: {
-              some: {
-                attributeNameId: equipmentAttributeName.id,
-                attributeValue: {
-                  value: {
-                    in: equipment,
-                  },
-                },
-              },
-            },
+            AND: buildEquipmentRequirementsFilter(equipment, equipmentAttributeName.id),
           },
           {
             NOT: {
@@ -108,16 +100,7 @@ export const shuffleExerciseAction = actionClient.schema(shuffleExerciseSchema).
               },
             },
             {
-              attributes: {
-                some: {
-                  attributeNameId: equipmentAttributeName.id,
-                  attributeValue: {
-                    value: {
-                      in: equipment,
-                    },
-                  },
-                },
-              },
+              AND: buildEquipmentRequirementsFilter(equipment, equipmentAttributeName.id),
             },
             {
               NOT: {

--- a/src/shared/lib/__tests__/exercise-equipment.test.ts
+++ b/src/shared/lib/__tests__/exercise-equipment.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { ExerciseAttributeValueEnum } from "@prisma/client";
+
+import {
+  equipmentRequirementsAreSelected,
+  inferAdditionalEquipmentRequirements,
+} from "../exercise-equipment";
+
+describe("inferAdditionalEquipmentRequirements", () => {
+  it("requires a bench for a dumbbell bench press", () => {
+    expect(
+      inferAdditionalEquipmentRequirements({
+        nameEn: "dumbbell bench press",
+        descriptionEn: "Lie on a flat bench and press the dumbbells overhead.",
+      }),
+    ).toEqual([ExerciseAttributeValueEnum.BENCH]);
+  });
+
+  it("does not turn a forward stepping cue into step equipment", () => {
+    expect(
+      inferAdditionalEquipmentRequirements({
+        nameEn: "forward lunge",
+        descriptionEn: "Step forward with your right foot and lower your hips.",
+      }),
+    ).toEqual([]);
+  });
+
+  it("treats towel resistance as band equipment", () => {
+    expect(
+      inferAdditionalEquipmentRequirements({
+        nameEn: "standing one arm row",
+        descriptionEn: "Hold a towel and pull it tightly with your other hand.",
+      }),
+    ).toEqual([ExerciseAttributeValueEnum.BANDS]);
+  });
+
+  it("requires a pull-up bar for hanging and front lever work", () => {
+    expect(
+      inferAdditionalEquipmentRequirements({
+        nameEn: "front lever",
+        descriptionEn: "Start hanging from a bar and raise your body to horizontal.",
+      }),
+    ).toEqual([ExerciseAttributeValueEnum.PULLUP_BAR]);
+  });
+
+  it("keeps pure floor movements bodyweight-only", () => {
+    expect(
+      inferAdditionalEquipmentRequirements({
+        nameEn: "glute bridge",
+        descriptionEn: "Lie on the floor with your knees bent and lift your hips.",
+      }),
+    ).toEqual([]);
+  });
+
+  it("does not infer a pull-up bar from limbs hanging toward the floor", () => {
+    expect(
+      inferAdditionalEquipmentRequirements({
+        nameEn: "dumbbell lying one arm rear lateral raise",
+        descriptionEn:
+          "Lie face down on a flat bench with a dumbbell in one hand, hanging towards the floor.",
+      }),
+    ).toEqual([ExerciseAttributeValueEnum.BENCH]);
+  });
+
+  it("does not infer a pull-up bar when wrists hang off a bench edge", () => {
+    expect(
+      inferAdditionalEquipmentRequirements({
+        nameEn: "cable wrist curl",
+        descriptionEn: "Rest your forearms on a bench, with your wrists hanging off the edge.",
+      }),
+    ).toEqual([ExerciseAttributeValueEnum.BENCH]);
+  });
+});
+
+describe("equipmentRequirementsAreSelected", () => {
+  it("requires every tag in a multiple-equipment exercise such as dumbbell and bench", () => {
+    expect(
+      equipmentRequirementsAreSelected(
+        [ExerciseAttributeValueEnum.DUMBBELL, ExerciseAttributeValueEnum.BENCH],
+        [ExerciseAttributeValueEnum.DUMBBELL, ExerciseAttributeValueEnum.BENCH],
+      ),
+    ).toBe(true);
+    expect(
+      equipmentRequirementsAreSelected(
+        [ExerciseAttributeValueEnum.DUMBBELL],
+        [ExerciseAttributeValueEnum.DUMBBELL, ExerciseAttributeValueEnum.BENCH],
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores stale body-only tags on material-equipment exercises", () => {
+    expect(
+      equipmentRequirementsAreSelected(
+        [ExerciseAttributeValueEnum.DUMBBELL, ExerciseAttributeValueEnum.BENCH],
+        [ExerciseAttributeValueEnum.DUMBBELL, ExerciseAttributeValueEnum.BENCH, ExerciseAttributeValueEnum.BODY_ONLY],
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps pure bodyweight exercises tied to body-only selection", () => {
+    expect(
+      equipmentRequirementsAreSelected(
+        [ExerciseAttributeValueEnum.BODY_ONLY],
+        [ExerciseAttributeValueEnum.BODY_ONLY],
+      ),
+    ).toBe(true);
+    expect(
+      equipmentRequirementsAreSelected(
+        [ExerciseAttributeValueEnum.DUMBBELL],
+        [ExerciseAttributeValueEnum.BODY_ONLY],
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/shared/lib/exercise-equipment.ts
+++ b/src/shared/lib/exercise-equipment.ts
@@ -1,0 +1,212 @@
+import { ExerciseAttributeValueEnum, type Prisma } from "@prisma/client";
+
+export interface ExerciseEquipmentSource {
+  name?: string | null;
+  nameEn?: string | null;
+  description?: string | null;
+  descriptionEn?: string | null;
+}
+
+export type InferredEquipmentRequirement =
+  | "BENCH"
+  | "STEP"
+  | "BOX"
+  | "DESK"
+  | "BANDS"
+  | "TRX"
+  | "PULLUP_BAR";
+
+function normalizeText(value: string | null | undefined): string {
+  return value
+    ?.replace(/<[^>]+>/g, " ")
+    .replace(/&[a-z]+;/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase() ?? "";
+}
+
+const floorWorkPattern = new RegExp(
+  "\\b(?:lie|lay|lying|seated|sit|kneel|kneeling|position yourself|start)\\b" +
+    "[^.]{0,12}\\b(?:on|onto)\\s+(?:the floor|a mat|the ground|the carpet)\\b",
+);
+
+const benchByTextPattern = new RegExp(
+  "\\b(?:on|onto|against|across|over|rest|support|chest against|lying|lie|lay|seated|sit|seat|kneel)\\b" +
+    ".{0,40}\\b(?:a|an|the|your|this|that|my|flat|incline|decline|adjustable|preacher|utility|weight|exercise)?\\s*benches?\\b",
+);
+
+const optionalTowelPattern =
+  /using your hands or a towel|with (?:your|the) hands or a towel|place a towel under|use a towel to (?:pad|cushion|wipe)/;
+
+function hasBenchRequirement(name: string, instructions: string): boolean {
+  const floorWork = floorWorkPattern;
+  const chairMetaphor = /\bsit(?:ting)? back into a chair\b|\bas if (?:you were |you are )?sitting\b|\bas though sitting\b/;
+
+  if (floorWork.test(instructions) || chairMetaphor.test(instructions)) return false;
+
+  return (
+    /\bbench\b/.test(name) ||
+    /\b(?:flat|incline|decline|adjustable|preacher|utility|weight|exercise|upright)\s+benches?\b/.test(instructions) ||
+    benchByTextPattern.test(instructions) ||
+    /\bbench[- ](?:press|row|curl|bridge|dip|fly|pullover|extension|raise|crunch|hip thrust)\b/.test(instructions) ||
+    /\b(?:on|onto|against)\b[^.]{0,20}\b(?:sturdy|stable|raised)?\s*(?:chair|bench)\b/.test(instructions)
+  );
+}
+
+function hasStepRequirement(name: string, instructions: string): boolean {
+  if (/\bstep\s+(?:forward|back|backward|aside|to the side|on the band|out to the)\b/.test(instructions)) {
+    return false;
+  }
+
+  if (/\bstep[- ]?ups?\b/.test(name) || /\bstaircase\b/.test(instructions)) return true;
+
+  const stepPattern = /\b(?:step|staircase|stair step)\b/g;
+  let match: RegExpExecArray | null;
+  while ((match = stepPattern.exec(instructions))) {
+    const context = instructions.slice(Math.max(0, match.index - 35), match.index + match[0].length + 35);
+    if (/\b(?:platform|box|raised|elevated|stair|aerobic|bench)\b/.test(context)) return true;
+  }
+
+  return false;
+}
+
+function hasBoxRequirement(name: string, instructions: string): boolean {
+  return (
+    /\b(?:box jump|box squat|box step|box dip|plyo box|plyometric box)\b/.test(name) ||
+    /\b(?:plyo|jump|plyometric)\s*box\b/.test(instructions) ||
+    /\b(?:on|onto)\s+(?:a|the|your)?\s*(?:plyo|jump|plyometric)?\s*box\b/.test(instructions)
+  );
+}
+
+function hasDeskRequirement(instructions: string): boolean {
+  return /\b(?:on|onto|against|under)\s+(?:a|an|the|your|sturdy|stable)?\s*(?:desk|table)\b/.test(instructions);
+}
+
+function hasTowelResistanceRequirement(name: string, instructions: string): boolean {
+  if (optionalTowelPattern.test(instructions)) {
+    return false;
+  }
+
+  return (
+    /\btowel\b/.test(name) ||
+    /\b(?:hold|grab|wrap|loop|clasp|grasp)\b.{0,15}\btowel\b/.test(instructions) ||
+    /\b(?:pull|press)\s+the towel\b/.test(instructions) ||
+    /\bresist (?:against|with) (?:the |a )?towel\b/.test(instructions) ||
+    /\busing a towel\b/.test(instructions)
+  );
+}
+
+function hasSuspensionRequirement(name: string, instructions: string): boolean {
+  return /\b(?:trx|suspension trainer|suspension strap|suspension system|gymnastic rings?)\b/.test(`${name} ${instructions}`);
+}
+
+function hasPullUpBarRequirement(name: string, instructions: string): boolean {
+  if (/\bbarbell\b/.test(name)) return false;
+
+  return (
+    /\b(?:pull|chin|muscle)[-\s]?ups?\b|\bfront lever\b|\bhanging\b/.test(name) ||
+    /\b(?:pull|chin)[-\s]?up bar\b/.test(instructions) ||
+    /\bhanging (?:from|on) (?:a |the )?bar\b/.test(instructions) ||
+    /\bhang(?:ing)? from (?:a |the )?(?:pull|chin)[-\s]?up bar\b/.test(instructions) ||
+    /\bgrab (?:a |the )?bar (?:overhead|above)\b/.test(instructions) ||
+    /\bhang from (?:a |the )?bar\b/.test(instructions)
+  );
+}
+
+export function inferAdditionalEquipmentRequirements(
+  exercise: ExerciseEquipmentSource,
+): InferredEquipmentRequirement[] {
+  const name = normalizeText(exercise.nameEn || exercise.name);
+  const localizedName = normalizeText(exercise.name);
+  const instructions = [
+    normalizeText(exercise.nameEn),
+    normalizeText(exercise.descriptionEn),
+    normalizeText(exercise.name),
+    normalizeText(exercise.description),
+  ].join(" ");
+
+  const requirements: InferredEquipmentRequirement[] = [];
+  const add = (requirement: InferredEquipmentRequirement) => {
+    if (!requirements.includes(requirement)) requirements.push(requirement);
+  };
+
+  if (hasBenchRequirement(`${name} ${localizedName}`, instructions)) add(ExerciseAttributeValueEnum.BENCH);
+  if (hasStepRequirement(name || localizedName, instructions)) add(ExerciseAttributeValueEnum.STEP);
+  if (hasBoxRequirement(name || localizedName, instructions)) add(ExerciseAttributeValueEnum.BOX);
+  if (hasDeskRequirement(instructions)) add(ExerciseAttributeValueEnum.DESK);
+  if (hasTowelResistanceRequirement(name || localizedName, instructions)) add(ExerciseAttributeValueEnum.BANDS);
+  if (hasSuspensionRequirement(name || localizedName, instructions)) add(ExerciseAttributeValueEnum.TRX);
+  if (hasPullUpBarRequirement(name || localizedName, instructions)) add(ExerciseAttributeValueEnum.PULLUP_BAR);
+
+  return requirements;
+}
+
+export function equipmentRequirementsAreSelected(
+  selectedEquipment: readonly ExerciseAttributeValueEnum[],
+  requiredEquipment: readonly ExerciseAttributeValueEnum[],
+): boolean {
+  const selected = new Set(selectedEquipment);
+  const materialRequirements = requiredEquipment.filter((value) => value !== ExerciseAttributeValueEnum.BODY_ONLY);
+
+  if (materialRequirements.some((requirement) => !selected.has(requirement))) return false;
+  if (materialRequirements.length > 0) return true;
+
+  return requiredEquipment.includes(ExerciseAttributeValueEnum.BODY_ONLY)
+    ? selected.has(ExerciseAttributeValueEnum.BODY_ONLY)
+    : true;
+}
+
+export function buildEquipmentRequirementsFilter(
+  selectedEquipment: readonly ExerciseAttributeValueEnum[],
+  equipmentAttributeNameId: string,
+): Prisma.ExerciseWhereInput[] {
+  if (selectedEquipment.length === 0) return [];
+
+  const selectedMaterialEquipment = selectedEquipment.filter((value) => value !== ExerciseAttributeValueEnum.BODY_ONLY);
+
+  if (selectedMaterialEquipment.length === 0) {
+    return [
+      {
+        attributes: {
+          some: {
+            attributeNameId: equipmentAttributeNameId,
+            attributeValue: { value: ExerciseAttributeValueEnum.BODY_ONLY },
+          },
+        },
+      },
+      {
+        NOT: {
+          attributes: {
+            some: {
+              attributeNameId: equipmentAttributeNameId,
+              attributeValue: { value: { notIn: [ExerciseAttributeValueEnum.BODY_ONLY] } },
+            },
+          },
+        },
+      },
+    ];
+  }
+
+  const acceptedValues = [...selectedEquipment, ExerciseAttributeValueEnum.BODY_ONLY];
+
+  return [
+    {
+      NOT: {
+        attributes: {
+          some: {
+            attributeNameId: equipmentAttributeNameId,
+            attributeValue: { value: { notIn: acceptedValues } },
+          },
+        },
+      },
+    },
+    {
+      attributes: {
+        some: {
+          attributeNameId: equipmentAttributeNameId,
+          attributeValue: { value: { in: selectedMaterialEquipment } },
+        },
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Infer hidden equipment requirements from exercise names and instructions (bench/chair/step/box/desk surfaces, suspension work, pull-up-bar hanging, and towel resistance).
- Keep multiple EQUIPMENT tags during CSV import and filter exercises using all required tags, not just any matching tag.
- Add an idempotent, add-only backfill script that defaults to dry run and writes only with `--apply`.
- Add Vitest coverage for equipment inference and all-requirements selection semantics.

## Why
Some exercises are tagged only with their primary equipment even though their instructions require another item. For example, a dumbbell bench press can still appear for a dumbbell-only selection because the current query treats multiple equipment tags as an OR match.

## Safety
The backfill only appends missing inferred tags and never removes existing tags. The importer drops stale `BODY_ONLY` from the resolved equipment set only when another material requirement was inferred, so pure bodyweight movements remain unchanged.

## Tests
- `pnpm install --frozen-lockfile`
- `pnpm test`
- `pnpm exec tsc --noEmit`
- Targeted ESLint check
- `git diff --check`