### PR TITLE
feat(workout-session): add "Share your success" workout image

### DIFF
--- a/locales/en.ts
+++ b/locales/en.ts
@@ -1720,6 +1720,10 @@ export default {
       exercise: "EXERCISE",
       repeat: "Repeat",
       delete: "Delete",
+      share_success: "Share your success",
+      share_card_title: "Workout Complete!",
+      share_card_exercises_label: "exercises completed",
+      share_card_footer: "workout.cool — Free & Open Source",
     },
     attribute_value: {
       bodyweight: "Bodyweight",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "eslint-config-prettier": "^10.1.1",
     "framer-motion": "^12.7.2",
     "geist": "^1.3.1",
+    "html-to-image": "^1.11.13",
     "lodash.debounce": "^4.0.8",
     "lucide-react": "^0.487.0",
     "mathjax-react": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       geist:
         specifier: ^1.3.1
         version: 1.4.2(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       lodash.debounce:
         specifier: ^4.0.8
         version: 4.0.8
@@ -3328,6 +3331,9 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
@@ -8308,6 +8314,8 @@ snapshots:
       hermes-estree: 0.25.1
 
   html-escaper@2.0.2: {}
+
+  html-to-image@1.11.13: {}
 
   html-to-text@9.0.5:
     dependencies:

--- a/src/features/workout-session/ui/share-workout-button.tsx
+++ b/src/features/workout-session/ui/share-workout-button.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Loader2, Share2 } from "lucide-react";
+import { useI18n } from "locales/client";
+import { toBlob } from "html-to-image";
+import { ExerciseAttributeValueEnum } from "@prisma/client";
+
+import { ShareWorkoutCard } from "./share-workout-card";
+
+import { Button } from "@/components/ui/button";
+
+interface ShareWorkoutButtonProps {
+  startedAt: string;
+  muscles: ExerciseAttributeValueEnum[];
+  exercisesCount: number;
+}
+
+function downloadBlob(blob: Blob, fileName: string) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = fileName;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+export function ShareWorkoutButton({ startedAt, muscles, exercisesCount }: ShareWorkoutButtonProps) {
+  const t = useI18n();
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  const handleShare = async () => {
+    const node = cardRef.current;
+    if (!node || isGenerating) return;
+
+    setIsGenerating(true);
+    try {
+      const blob = await toBlob(node, { pixelRatio: 2 });
+      if (!blob) return;
+
+      const fileName = "workout-cool-summary.png";
+      const file = new File([blob], fileName, { type: "image/png" });
+
+      if (navigator.canShare?.({ files: [file] })) {
+        await navigator.share({
+          files: [file],
+          title: t("workout_builder.session.share_card_title"),
+        });
+      } else {
+        downloadBlob(blob, fileName);
+      }
+    } catch (error) {
+      // AbortError is thrown when the user cancels the native share sheet — not a failure.
+      if (error instanceof Error && error.name !== "AbortError") {
+        console.error("Failed to generate workout share image", error);
+      }
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  return (
+    <>
+      <Button disabled={isGenerating} onClick={handleShare} variant="secondary">
+        {isGenerating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Share2 className="h-4 w-4" />}
+        {t("workout_builder.session.share_success")}
+      </Button>
+
+      {/* Rendered off-screen; only used as a source for html-to-image capture. */}
+      <div aria-hidden className="pointer-events-none fixed left-[-9999px] top-0" style={{ transform: "translateZ(0)" }}>
+        <ShareWorkoutCard exercisesCount={exercisesCount} muscles={muscles} ref={cardRef} startedAt={startedAt} />
+      </div>
+    </>
+  );
+}

--- a/src/features/workout-session/ui/share-workout-card.tsx
+++ b/src/features/workout-session/ui/share-workout-card.tsx
@@ -1,0 +1,63 @@
+import { forwardRef } from "react";
+import Image from "next/image";
+import { Dumbbell } from "lucide-react";
+import { useCurrentLocale, useI18n } from "locales/client";
+import Logo from "@public/logo.png";
+import { ExerciseAttributeValueEnum } from "@prisma/client";
+
+import { getAttributeValueLabel } from "@/shared/lib/attribute-value-translation";
+
+interface ShareWorkoutCardProps {
+  startedAt: string;
+  muscles: ExerciseAttributeValueEnum[];
+  exercisesCount: number;
+}
+
+/**
+ * Social-friendly summary card for a completed workout, rendered off-screen
+ * and captured as an image by ShareWorkoutButton via html-to-image.
+ */
+export const ShareWorkoutCard = forwardRef<HTMLDivElement, ShareWorkoutCardProps>(function ShareWorkoutCard(
+  { startedAt, muscles, exercisesCount },
+  ref,
+) {
+  const t = useI18n();
+  const locale = useCurrentLocale();
+  const date = new Date(startedAt).toLocaleDateString(locale, { day: "numeric", month: "long", year: "numeric" });
+
+  return (
+    <div
+      className="relative flex h-[750px] w-[600px] flex-col justify-between overflow-hidden bg-gradient-to-br from-blue-600 via-blue-500 to-emerald-500 p-10 text-white"
+      ref={ref}
+    >
+      <div className="flex items-center gap-2">
+        <Image alt="" className="h-8 w-8 rounded-md" height={32} src={Logo} width={32} />
+        <span className="text-lg font-bold">Workout.cool</span>
+      </div>
+
+      <div className="flex flex-col items-center text-center">
+        <span className="text-7xl">🏆</span>
+        <h1 className="mt-6 text-4xl font-extrabold leading-tight">{t("workout_builder.session.share_card_title")}</h1>
+        <p className="mt-3 text-lg text-white/80">{date}</p>
+
+        {muscles.length > 0 && (
+          <div className="mt-8 flex flex-wrap justify-center gap-2">
+            {muscles.map((muscle) => (
+              <span className="rounded-full bg-white/15 px-4 py-1.5 text-base font-semibold" key={muscle}>
+                {getAttributeValueLabel(muscle, t)}
+              </span>
+            ))}
+          </div>
+        )}
+
+        <div className="mt-8 flex items-center gap-3 rounded-2xl bg-white/10 px-6 py-3">
+          <Dumbbell className="h-6 w-6" />
+          <span className="text-xl font-bold">{exercisesCount}</span>
+          <span className="text-lg text-white/80">{t("workout_builder.session.share_card_exercises_label")}</span>
+        </div>
+      </div>
+
+      <p className="text-center text-sm font-medium text-white/70">{t("workout_builder.session.share_card_footer")}</p>
+    </div>
+  );
+});

--- a/src/features/workout-session/ui/workout-session-sets.tsx
+++ b/src/features/workout-session/ui/workout-session-sets.tsx
@@ -10,6 +10,7 @@ import TrophyImg from "@public/images/trophy.png";
 
 import { FavoriteExerciseButton } from "../../workout-builder/ui/favorite-exercise-button";
 import { WorkoutSessionSet } from "./workout-session-set";
+import { ShareWorkoutButton } from "./share-workout-button";
 
 import { cn } from "@/shared/lib/utils";
 import { useWorkoutFeedback } from "@/shared/hooks/use-workout-feedback";
@@ -78,7 +79,12 @@ export function WorkoutSessionSets({
         <Image alt={t("workout_builder.session.complete") + " trophy"} className="w-56 h-56" src={TrophyImg} />
         <h2 className="text-2xl font-bold mb-2">{t("workout_builder.session.complete") + " ! 🎉"}</h2>
         <p className="text-lg text-slate-600 mb-6">{t("workout_builder.session.workout_in_progress")}</p>
-        <Button onClick={() => router.push("/profile")}>{t("commons.go_to_profile")}</Button>
+        <div className="flex flex-col sm:flex-row gap-3">
+          <Button onClick={() => router.push("/profile")}>{t("commons.go_to_profile")}</Button>
+          {session && (
+            <ShareWorkoutButton exercisesCount={session.exercises.length} muscles={session.muscles} startedAt={session.startedAt} />
+          )}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Summary

At the end of a workout, users can now generate and share a social-friendly summary image straight from the session-complete screen, next to the existing "Go to my profile" button.

## Why

Closes #54. Boosts motivation and gives users something worth posting after a workout, per the issue.

## How

- **`ShareWorkoutCard`**: the visual card — date, muscle groups worked (reusing the existing `getAttributeValueLabel` translation helper), number of exercises completed, and workout.cool branding (the same logo used in the header). Rendered at a fixed 600×750 size for a clean social-ratio export.
- **`ShareWorkoutButton`**: renders the card off-screen (`position: fixed; left: -9999px`, not `display: none`, so it stays measurable/paintable), captures it as a PNG via `html-to-image`'s `toBlob` (2x pixel ratio for crisp output), then:
  - Uses the native Web Share API (`navigator.share` with a `File`) when supported — this is the primary path on mobile, per the issue's "mobile focus."
  - Falls back to a plain client-side download otherwise.
- Wired into `WorkoutSessionSets`' congrats screen, reusing data already present in the session store (`session.muscles`, `session.exercises`, `session.startedAt`) — no backend or schema changes needed.
- Added `html-to-image` as a new dependency (as suggested in the issue itself). Nothing else added.

Card design: a blue-to-emerald gradient, the workout.cool logo + wordmark top-left, a trophy emoji, "Workout Complete!" heading, the formatted date, muscle-group pill badges (consistent semi-transparent white, chosen after an earlier per-muscle-tinted version had contrast issues against parts of the gradient), an exercises-completed stat pill with a dumbbell icon, and a "workout.cool — Free & Open Source" footer.

**On translations**: I added the new UI strings to `locales/en.ts` only. I'm not confident enough in Spanish/French/Portuguese/Russian/Chinese to add accurate translations myself, and didn't want to introduce low-quality machine-translated copy — the app falls back to English for missing keys (verified this is already the case elsewhere in the codebase, e.g. `en.ts` and `fr.ts` don't have identical key sets today). Happy to add translations if you'd rather have them from day one, or leave it for a translation-focused follow-up.

## Testing

- `pnpm exec tsc --noEmit` — clean.
- `pnpm exec eslint` on the changed files — clean.
- `pnpm exec vitest run` — all 28 existing tests still pass (no relevant unit-testable pure logic was introduced here — the existing test suite is small and focused on pure calculation/formatting functions elsewhere in the app, which this feature doesn't have; happy to add tests if you'd like a specific approach).
- `pnpm run build` — full production build succeeds.
- I don't have Docker/a local Postgres available in this environment, so I wasn't able to run the app end-to-end or `pnpm test:e2e` to click through the actual share/download flow. I visually verified the card's design (colors, contrast, layout at the target 600×750 size) by rendering the exact markup standalone before wiring it in, but I can't attach that image here from my current setup. Would appreciate a maintainer double-checking the live share/download behavior, especially the `navigator.share` path on an actual mobile device — happy to iterate on the design based on what it actually looks like running.

## Related Issue

Closes #54